### PR TITLE
Add support for USB-Botbase

### DIFF
--- a/AutoLegalityMod/AutoModPlugins.csproj
+++ b/AutoLegalityMod/AutoModPlugins.csproj
@@ -34,6 +34,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="LibUsbDotNet.LibUsbDotNet, Version=2.2.0.0, Culture=neutral, PublicKeyToken=c677239abe1e02a9, processorArchitecture=MSIL">
+      <HintPath>..\packages\LibUsbDotNet.2.2.29\lib\net45\LibUsbDotNet.LibUsbDotNet.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="PKHeX.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\PKHeX.Core.20.8.7\lib\net46\PKHeX.Core.dll</HintPath>
     </Reference>

--- a/AutoLegalityMod/GUI/LiveHexUI.Designer.cs
+++ b/AutoLegalityMod/GUI/LiveHexUI.Designer.cs
@@ -39,7 +39,7 @@
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.checkBox2 = new System.Windows.Forms.CheckBox();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
-            this.TB_Offset = new HexTextBox();
+            this.TB_Offset = new AutoModPlugins.HexTextBox();
             this.L_ReadOffset = new System.Windows.Forms.Label();
             this.B_ReadOffset = new System.Windows.Forms.Button();
             this.L_Slot = new System.Windows.Forms.Label();
@@ -52,8 +52,9 @@
             this.B_ReadRAM = new System.Windows.Forms.Button();
             this.RamSize = new System.Windows.Forms.TextBox();
             this.label2 = new System.Windows.Forms.Label();
-            this.RamOffset = new HexTextBox();
+            this.RamOffset = new AutoModPlugins.HexTextBox();
             this.label1 = new System.Windows.Forms.Label();
+            this.L_USBState = new System.Windows.Forms.Label();
             this.groupBox1.SuspendLayout();
             this.groupBox2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_Slot)).BeginInit();
@@ -358,6 +359,16 @@
             this.label1.Text = "Offset:";
             this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
+            // L_USBState
+            // 
+            this.L_USBState.AutoSize = true;
+            this.L_USBState.Location = new System.Drawing.Point(12, 15);
+            this.L_USBState.Name = "L_USBState";
+            this.L_USBState.Size = new System.Drawing.Size(100, 13);
+            this.L_USBState.TabIndex = 11;
+            this.L_USBState.Text = "USB-Botbase mode";
+            this.L_USBState.Visible = false;
+            // 
             // LiveHexUI
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -371,6 +382,7 @@
             this.Controls.Add(this.TB_Port);
             this.Controls.Add(this.L_IP);
             this.Controls.Add(this.TB_IP);
+            this.Controls.Add(this.L_USBState);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
             this.MaximizeBox = false;
             this.MinimizeBox = false;
@@ -419,5 +431,6 @@
         private System.Windows.Forms.Label label2;
         private HexTextBox RamOffset;
         private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label L_USBState;
     }
 }

--- a/AutoLegalityMod/GUI/LiveHexUI.cs
+++ b/AutoLegalityMod/GUI/LiveHexUI.cs
@@ -22,6 +22,8 @@ namespace AutoModPlugins
         private readonly LiveHexController Remote;
         private readonly SaveDataEditor<PictureBox> x;
 
+        private readonly InjectorCommunicationType CurrentInjectionType;
+
 #pragma warning disable CA2213 // Disposable fields should be disposed
         private readonly ComboBox BoxSelect; // this is just us holding a reference; disposal is done by its parent
 #pragma warning restore CA2213 // Disposable fields should be disposed
@@ -29,12 +31,14 @@ namespace AutoModPlugins
         public LiveHexUI(ISaveFileProvider sav, IPKMView editor)
         {
             SAV = sav;
-            Remote = new LiveHexController(sav, editor);
+            CurrentInjectionType = Properties.AutoLegality.Default.USBBotBasePreferred ? InjectorCommunicationType.USB : InjectorCommunicationType.SocketNetwork;
+            Remote = new LiveHexController(sav, editor, CurrentInjectionType);
 
             InitializeComponent();
             WinFormsTranslator.TranslateInterface(this, WinFormsTranslator.CurrentLanguage);
 
             TB_IP.Text = Properties.AutoLegality.Default.LatestIP;
+            SetInjectionTypeView();
 
             // add an event to the editor
             // ReSharper disable once SuspiciousTypeConversion.Global
@@ -83,7 +87,7 @@ namespace AutoModPlugins
                 var currver = validversions[0];
                 foreach (LiveHeXVersion ver in validversions)
                 {
-                    Remote.Bot = new PokeSysBotMini(ver);
+                    Remote.Bot = new PokeSysBotMini(ver, CurrentInjectionType);
                     Remote.Bot.com.IP = TB_IP.Text;
                     Remote.Bot.com.Port = int.Parse(TB_Port.Text);
                     Remote.Bot.com.Connect();
@@ -103,7 +107,7 @@ namespace AutoModPlugins
 
                 if (!ConnectionEstablished)
                 {
-                    Remote.Bot = new PokeSysBotMini(currver);
+                    Remote.Bot = new PokeSysBotMini(currver, CurrentInjectionType);
                     Remote.Bot.com.IP = TB_IP.Text;
                     Remote.Bot.com.Port = int.Parse(TB_Port.Text);
                     Remote.Bot.com.Connect();
@@ -208,6 +212,15 @@ namespace AutoModPlugins
 
         public ISlotInfo GetSlotData(PictureBox view) => null;
         public int GetViewIndex(ISlotInfo slot) => -1;
+
+        private void SetInjectionTypeView()
+        {
+            TB_IP.Visible = CurrentInjectionType == InjectorCommunicationType.SocketNetwork;
+            TB_Port.Visible = CurrentInjectionType == InjectorCommunicationType.SocketNetwork;
+            L_IP.Visible = CurrentInjectionType == InjectorCommunicationType.SocketNetwork;
+            L_Port.Visible = CurrentInjectionType == InjectorCommunicationType.SocketNetwork;
+            L_USBState.Visible = CurrentInjectionType == InjectorCommunicationType.USB;
+        }
     }
 
     internal class HexTextBox : TextBox

--- a/AutoLegalityMod/Properties/AutoLegality.Designer.cs
+++ b/AutoLegalityMod/Properties/AutoLegality.Designer.cs
@@ -12,7 +12,7 @@ namespace AutoModPlugins.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.4.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.6.0.0")]
     internal sealed partial class AutoLegality : global::System.Configuration.ApplicationSettingsBase {
         
         private static AutoLegality defaultInstance = ((AutoLegality)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new AutoLegality())));
@@ -188,6 +188,18 @@ namespace AutoModPlugins.Properties {
             }
             set {
                 this["PrioritizeGame"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool USBBotBasePreferred {
+            get {
+                return ((bool)(this["USBBotBasePreferred"]));
+            }
+            set {
+                this["USBBotBasePreferred"] = value;
             }
         }
     }

--- a/AutoLegalityMod/Properties/AutoLegality.settings
+++ b/AutoLegalityMod/Properties/AutoLegality.settings
@@ -44,5 +44,8 @@
     <Setting Name="PrioritizeGame" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="USBBotBasePreferred" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/AutoLegalityMod/app.config
+++ b/AutoLegalityMod/app.config
@@ -55,6 +55,9 @@
             <setting name="PrioritizeGame" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="USBBotBasePreferred" serializeAs="String">
+                <value>False</value>
+            </setting>
         </AutoModPlugins.Properties.AutoLegality>
     </userSettings>
 </configuration>

--- a/AutoLegalityMod/packages.config
+++ b/AutoLegalityMod/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="LibUsbDotNet" version="2.2.29" targetFramework="net46" />
   <package id="PKHeX.Core" version="20.8.7" targetFramework="net46" />
 </packages>

--- a/PKHeX.Core.AutoMod/BotController/ICommunicator.cs
+++ b/PKHeX.Core.AutoMod/BotController/ICommunicator.cs
@@ -1,5 +1,11 @@
 ﻿namespace PKHeX.Core.AutoMod
 {
+    public enum InjectorCommunicationType
+    {
+        SocketNetwork = 0,
+        USB = 1
+    }
+
     public interface ICommunicator
     {
         void Connect();

--- a/PKHeX.Core.AutoMod/BotController/LiveHexController.cs
+++ b/PKHeX.Core.AutoMod/BotController/LiveHexController.cs
@@ -6,12 +6,12 @@
         private readonly IPKMView Editor;
         public PokeSysBotMini Bot;
 
-        public LiveHexController(ISaveFileProvider boxes, IPKMView editor)
+        public LiveHexController(ISaveFileProvider boxes, IPKMView editor, InjectorCommunicationType ict)
         {
             SAV = boxes;
             Editor = editor;
             var ValidVers = RamOffsets.GetValidVersions(boxes.SAV);
-            Bot = new PokeSysBotMini(ValidVers[0]);
+            Bot = new PokeSysBotMini(ValidVers[0], ict);
         }
 
         public void ChangeBox(int box)

--- a/PKHeX.Core.AutoMod/BotController/PokeSysBotMini.cs
+++ b/PKHeX.Core.AutoMod/BotController/PokeSysBotMini.cs
@@ -14,10 +14,10 @@ namespace PKHeX.Core.AutoMod
         public ICommunicator com;
         public bool Connected => com.Connected;
 
-        public PokeSysBotMini(LiveHeXVersion lv)
+        public PokeSysBotMini(LiveHeXVersion lv, InjectorCommunicationType ict)
         {
             Version = lv;
-            com = RamOffsets.GetCommunicator(lv);
+            com = RamOffsets.GetCommunicator(lv, ict);
             BoxStart = RamOffsets.GetB1S1Offset(lv);
             SlotSize = RamOffsets.GetSlotSize(lv);
             SlotCount = RamOffsets.GetSlotCount(lv);

--- a/PKHeX.Core.AutoMod/BotController/RamOffsets.cs
+++ b/PKHeX.Core.AutoMod/BotController/RamOffsets.cs
@@ -30,14 +30,14 @@ namespace PKHeX.Core.AutoMod
             return new[] { LiveHeXVersion.SWSH_Rigel2 };
         }
 
-        public static ICommunicator GetCommunicator(LiveHeXVersion lv)
+        public static ICommunicator GetCommunicator(LiveHeXVersion lv, InjectorCommunicationType ict)
         {
             return lv switch
             {
-                LiveHeXVersion.LGPE_v102 => new SysBotMini(),
-                LiveHeXVersion.SWSH_Orion => new SysBotMini(),
-                LiveHeXVersion.SWSH_Rigel1 => new SysBotMini(),
-                LiveHeXVersion.SWSH_Rigel2 => new SysBotMini(),
+                LiveHeXVersion.LGPE_v102 => GetSwitchInterface(ict),
+                LiveHeXVersion.SWSH_Orion => GetSwitchInterface(ict),
+                LiveHeXVersion.SWSH_Rigel1 => GetSwitchInterface(ict),
+                LiveHeXVersion.SWSH_Rigel2 => GetSwitchInterface(ict),
                 LiveHeXVersion.UM_v12 => new NTRMini(),
                 LiveHeXVersion.US_v12 => new NTRMini(),
                 LiveHeXVersion.SM_v12 => new NTRMini(),
@@ -166,6 +166,17 @@ namespace PKHeX.Core.AutoMod
                 LiveHeXVersion.US_v12 => 0x3F3424,
                 LiveHeXVersion.SM_v12 => 0x3E14C0,
                 _ => 0
+            };
+        }
+
+        private static ICommunicator GetSwitchInterface(InjectorCommunicationType ict)
+        {
+            // No conditional expression possible
+            return ict switch
+            {
+                InjectorCommunicationType.SocketNetwork => new SysBotMini(),
+                InjectorCommunicationType.USB => new UsbBotMini(),
+                _ => new SysBotMini()
             };
         }
     }

--- a/PKHeX.Core.AutoMod/BotController/SwitchCommand.cs
+++ b/PKHeX.Core.AutoMod/BotController/SwitchCommand.cs
@@ -9,7 +9,7 @@ namespace PKHeX.Core.AutoMod
     public static class SwitchCommand
     {
         private static readonly Encoding Encoder = Encoding.UTF8;
-        private static byte[] Encode(string command) => Encoder.GetBytes(command + "\r\n");
+        private static byte[] Encode(string command, bool addrn = true) => Encoder.GetBytes(addrn ? command + "\r\n" : command);
 
         /// <summary>
         /// Removes the virtual controller from the bot. Allows physical controllers to control manually.
@@ -84,5 +84,21 @@ namespace PKHeX.Core.AutoMod
         /// <param name="data">Data to write</param>
         /// <returns>Encoded command bytes</returns>
         public static byte[] Poke(uint offset, byte[] data) => Encode($"poke 0x{offset:X8} 0x{string.Concat(data.Select(z => $"{z:X2}"))}");
+
+        /// <summary>
+        /// (Without return characters for USB-Botbase) Requests the Bot to send <see cref="count"/> bytes from <see cref="offset"/>.
+        /// </summary>
+        /// <param name="offset">Address of the data</param>
+        /// <param name="count">Amount of bytes</param>
+        /// <returns>Encoded command bytes</returns>
+        public static byte[] PeekRaw(uint offset, int count) => Encode($"peek 0x{offset:X8} {count}", false);
+
+        /// <summary>
+        /// (Without return characters for USB-Botbase) Sends the Bot <see cref="data"/> to be written to <see cref="offset"/>.
+        /// </summary>
+        /// <param name="offset">Address of the data</param>
+        /// <param name="data">Data to write</param>
+        /// <returns>Encoded command bytes</returns>
+        public static byte[] PokeRaw(uint offset, byte[] data) => Encode($"poke 0x{offset:X8} 0x{string.Concat(data.Select(z => $"{z:X2}"))}", false);
     }
 }

--- a/PKHeX.Core.AutoMod/BotController/UsbBotMini.cs
+++ b/PKHeX.Core.AutoMod/BotController/UsbBotMini.cs
@@ -1,0 +1,203 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using LibUsbDotNet;
+using LibUsbDotNet.Main;
+
+namespace PKHeX.Core.AutoMod
+{
+    public class UsbBotMini : ICommunicator
+    {
+        private const int MaximumTransferSize = 468; // byte limitation of USB-Botbase over Android for ACNHMS, assumed same here.
+
+        public string IP = string.Empty;
+        public int Port = 0;
+
+        private UsbDevice? SwDevice;
+        private UsbEndpointReader? reader;
+        private UsbEndpointWriter? writer;
+
+        public bool Connected;
+
+        private readonly object _sync = new object();
+
+        bool ICommunicator.Connected { get => Connected; set => Connected = value; }
+        int ICommunicator.Port { get => Port; set => Port = value; }
+        string ICommunicator.IP { get => IP; set => IP = value; }
+
+        /// <summary>
+        /// Soft connect USB reader and writer, no persistent connection will be active due to limitations of USB-Botbase.
+        /// </summary>
+        public void Connect()
+        {
+            lock (_sync)
+            {
+                // Find and open the usb device.
+                foreach (UsbRegistry ur in UsbDevice.AllDevices)
+                {
+                    if (ur.Vid == 1406 && ur.Pid == 12288)
+                        SwDevice = ur.Device;
+                }
+                //SwDevice = UsbDevice.OpenUsbDevice(MyUsbFinder);
+
+                // If the device is open and ready
+                if (SwDevice == null)
+                {
+                    throw new Exception("Device Not Found.");
+                }
+
+                if (SwDevice.IsOpen)
+                    SwDevice.Close();
+                SwDevice.Open();
+
+                if (SwDevice is IUsbDevice wholeUsbDevice)
+                {
+                    // This is a "whole" USB device. Before it can be used, 
+                    // the desired configuration and interface must be selected.
+
+                    // Select config #1
+                    wholeUsbDevice.SetConfiguration(1);
+
+                    // Claim interface #0.
+                    bool resagain = wholeUsbDevice.ClaimInterface(0);
+                    if (!resagain)
+                    {
+                        wholeUsbDevice.ReleaseInterface(0);
+                        wholeUsbDevice.ClaimInterface(0);
+                    }
+                }
+                else
+                {
+                    Disconnect();
+                    throw new Exception("Device is using WinUSB driver. Use libusbK and create a filter");
+                }
+
+                // open read write endpoints 1.
+                reader = SwDevice.OpenEndpointReader(ReadEndpointID.Ep01);
+                writer = SwDevice.OpenEndpointWriter(WriteEndpointID.Ep01);
+
+                Connected = true;
+            }
+        }
+
+        public void Disconnect()
+        {
+            lock (_sync)
+            {
+                if (SwDevice != null)
+                {
+                    if (SwDevice.IsOpen)
+                    {
+                        if (SwDevice is IUsbDevice wholeUsbDevice)
+                            wholeUsbDevice.ReleaseInterface(0);
+                        SwDevice.Close();
+                    }
+                }
+
+                reader?.Dispose();
+                writer?.Dispose();
+                Connected = false;
+            }
+        }
+
+        private int ReadInternal(byte[] buffer)
+        {
+            byte[] sizeOfReturn = new byte[4];
+
+            //read size, no error checking as of yet, should be the required 368 bytes
+            if (reader == null)
+                throw new Exception("USB writer is null, you may have disconnected the device during previous function");
+
+            reader.Read(sizeOfReturn, 5000, out _);
+
+            //read stack
+            reader.Read(buffer, 5000, out var lenVal);
+            return lenVal;
+        }
+
+        private int SendInternal(byte[] buffer)
+        {
+            if (writer == null)
+                throw new Exception("USB writer is null, you may have disconnected the device during previous function");
+
+            uint pack = (uint)buffer.Length + 2;
+            var ec = writer.Write(BitConverter.GetBytes(pack), 2000, out _);
+            if (ec != ErrorCode.None)
+            {
+                Disconnect();
+                throw new Exception(UsbDevice.LastErrorString);
+            }
+            ec = writer.Write(buffer, 2000, out var l);
+            if (ec != ErrorCode.None)
+            {
+                Disconnect();
+                throw new Exception(UsbDevice.LastErrorString);
+            }
+            return l;
+        }
+
+        public int Read(byte[] buffer)
+        {
+            lock (_sync)
+            {
+                return ReadInternal(buffer);
+            }
+        }
+
+        public byte[] ReadBytes(uint offset, int length)
+        {
+            if (length > MaximumTransferSize)
+                return ReadBytesLarge(offset, length);
+            lock (_sync)
+            {
+                var cmd = SwitchCommand.PeekRaw(offset, length);
+                SendInternal(cmd);
+
+                // give it time to push data back
+                Thread.Sleep(1);
+
+                var buffer = new byte[length];
+                var _ = ReadInternal(buffer);
+                //return Decoder.ConvertHexByteStringToBytes(buffer);
+                return buffer;
+            }
+        }
+
+        public void WriteBytes(byte[] data, uint offset)
+        {
+            if (data.Length > MaximumTransferSize)
+                WriteBytesLarge(data, offset);
+            lock (_sync)
+            {
+                SendInternal(SwitchCommand.PokeRaw(offset, data));
+
+                // give it time to push data back
+                Thread.Sleep(1);
+            }
+        }
+
+        private void WriteBytesLarge(byte[] data, uint offset)
+        {
+            int byteCount = data.Length;
+            for (int i = 0; i < byteCount; i += MaximumTransferSize)
+                WriteBytes(SubArray(data, i, MaximumTransferSize), offset + (uint)i);
+        }
+
+        private byte[] ReadBytesLarge(uint offset, int length)
+        {
+            List<byte> read = new List<byte>();
+            for (int i = 0; i < length; i += MaximumTransferSize)
+                read.AddRange(ReadBytes(offset + (uint)i, Math.Min(MaximumTransferSize, length - i)));
+            return read.ToArray();
+        }
+
+        private static T[] SubArray<T>(T[] data, int index, int length)
+        {
+            if (index + length > data.Length)
+                length = data.Length - index;
+            T[] result = new T[length];
+            Array.Copy(data, index, result, 0, length);
+            return result;
+        }
+    }
+}

--- a/PKHeX.Core.AutoMod/PKHeX.Core.AutoMod.csproj
+++ b/PKHeX.Core.AutoMod/PKHeX.Core.AutoMod.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="LibUsbDotNet" Version="2.2.29" />
     <PackageReference Include="PKHeX.Core" Version="20.8.7" />
   </ItemGroup>
 


### PR DESCRIPTION
Perhaps a lot more has changed than required (the setting could just be pulled in RamOffsets.cs, I can revert to this if preferred and not pass the InjectorCommunicationType enum as it is right now)

Usage for other people that might be reading this:
USB-Botbase setup:
1) Install [USB-Botbase](https://github.com/fishguy6564/USB-Botbase) to console. Won't work at the same time as sys-botbase or other USB sysmodules or hb apps such as nxmtp.
2) Use [Zadig](http://www.unitrunker.com/zadig.html) to install libusbK while USB-Botbase is running and connected to device
3) Install [libusb](http://www.mediafire.com/file/wdx5lu4c37sm1cv/libusb-win32-devel-filter-1.2.6.0.exe/file) and create a filter for the switch
3a) And/or install [libusbdotnet](https://sourceforge.net/projects/libusbdotnet/) and do the same as above if the above doesn't allow you to read/write RAM correctly.
4) (optional) ensure everything is working correctly by running the python script at the [USB-Botbase](https://github.com/fishguy6564/USB-Botbase) repo (requires pyusb installed too)

PkHex:
1) Go to Tools > Auto Legality Mod > Plugin Settings and change the "USBBotBasePreferred" setting to True
2) Go to Tools > Auto Legality Mod > Open LiveHeX
3) Hit Connect

and everything should work as it does with sys-botbase but is a little slower due to the 468 byte limitation of USB on switch at this time.
