### PR TITLE
set default tls request version of setup script

### DIFF
--- a/setup_bleedingedge.ps1
+++ b/setup_bleedingedge.ps1
@@ -1,4 +1,7 @@
-﻿# Powershell script to download PKHeX and Plugins (latest)
+﻿# Setting the TLS protocol to 1.2 instead of the default 1.0
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+# Powershell script to download PKHeX and Plugins (latest)
 Write-Host "PKHeX and PKHeX-Plugins downloader (latest releases)"
 Write-Host "please report any issues with this setup file via GitHub issues at https://github.com/architdate/PKHeX-Plugins/issues"
 Write-Host ""

--- a/setup_stable.ps1
+++ b/setup_stable.ps1
@@ -1,3 +1,6 @@
+# Setting the TLS protocol to 1.2 instead of the default 1.0
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
 # Powershell script to download PKHeX and Plugins (stable)
 Write-Host "PKHeX and PKHeX-Plugins downloader (stable releases)"
 Write-Host "please report any issues with this setup file via GitHub issues at https://github.com/architdate/PKHeX-Plugins/issues"


### PR DESCRIPTION
this fixes `Invoke-WebRequest : The request was aborted: Could not create SSL/TLS secure channel`, powershell defaults to tls v1.0 but some websites do not support this tls version anymore, [related stackoverflow question](https://stackoverflow.com/questions/41618766/powershell-invoke-webrequest-fails-with-ssl-tls-secure-channel)