### PR TITLE
Legalizer now works with Generation 1 tradebacks

### DIFF
--- a/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
@@ -67,6 +67,9 @@ namespace PKHeX.Core.AutoMod
                     else continue;
                 }
 
+                if (pk is PK1 gen1Pk)
+                    gen1Pk.Catch_Rate = gen1Pk.Gen2Item; // Simulate a gen 2 trade/tradeback to allow tradeback moves
+
                 var la = new LegalityAnalysis(pk);
                 if (la.Valid)
                 {

--- a/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
@@ -67,7 +67,7 @@ namespace PKHeX.Core.AutoMod
                     else continue;
                 }
 
-                if (pk is PK1 gen1Pk)
+                if (pk is PK1 gen1Pk && ParseSettings.AllowGen1Tradeback)
                     gen1Pk.Catch_Rate = gen1Pk.Gen2Item; // Simulate a gen 2 trade/tradeback to allow tradeback moves
 
                 var la = new LegalityAnalysis(pk);


### PR DESCRIPTION
Simulates trading to a Generation 2 game. Catch Rate becomes updated to the corresponding valid Generation 2 item (requires kwsch/PKHeX@cc5a950)

Test case: RBY Mr. Mime with Fire Punch fails to legalize in the current version, but is successfully legalized with this PR
[122 - MARCEL - 77D7.zip](https://github.com/architdate/PKHeX-Plugins/files/5294352/122.-.MARCEL.-.77D7.zip)
