### PR TITLE
Move Sanitize EVs functionality to APILegality and use PKM data

### DIFF
--- a/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
@@ -60,6 +60,7 @@ namespace PKHeX.Core.AutoMod
                     continue;
 
                 ApplySetDetails(pk, set, raw, dest, enc);
+                pk.SanitizeEVs();
                 if (pk is IGigantamax gmax && gmax.CanGigantamax != set.CanGigantamax)
                 {
                     if (gmax.CanToggleGigantamax(pk.Species, enc.Species))
@@ -77,6 +78,18 @@ namespace PKHeX.Core.AutoMod
             }
             satisfied = false;
             return template;
+        }
+
+        private static void SanitizeEVs(this PKM pk)
+        {
+            var copy = (int[])pk.EVs.Clone();
+            for (int i = 0; i < copy.Length; i++)
+            {
+                if (copy[i] > pk.MaxEV)
+                    copy[i] = pk.MaxEV;
+            }
+
+            pk.EVs = copy;
         }
 
         /// <summary>

--- a/PKHeX.Core.AutoMod/AutoMod/RegenTemplate.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/RegenTemplate.cs
@@ -1,4 +1,4 @@
-﻿// ReSharper disable AutoPropertyCanBeMadeGetOnly.Global
+// ReSharper disable AutoPropertyCanBeMadeGetOnly.Global
 
 using System.Collections.Generic;
 
@@ -42,7 +42,7 @@ namespace PKHeX.Core.AutoMod
             Nature = set.Nature;
             Form = set.Form;
             FormIndex = set.FormIndex;
-            EVs = SanitizeEVs(set.EVs);
+            EVs = set.EVs;
             IVs = set.IVs;
             HiddenPowerType = set.HiddenPowerType;
             Moves = set.Moves;
@@ -90,17 +90,6 @@ namespace PKHeX.Core.AutoMod
                 // Remove from lines
                 lines.RemoveAt(i--);
             }
-        }
-
-        private static int[] SanitizeEVs(int[] evs)
-        {
-            var copy = (int[])evs.Clone();
-            for (int i = 0; i < evs.Length; i++)
-            {
-                if (copy[i] > 252)
-                    copy[i] = 252;
-            }
-            return copy;
         }
     }
 }


### PR DESCRIPTION
Fixes the first noted issue in #55 

Does not fix the related issue of EVs for Smogon Sets being set as 0.