### PR TITLE
Showdown/Smogon imports now properly set Stat XP

### DIFF
--- a/PKHeX.Core.AutoMod/AutoMod/ShowdownEdits.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/ShowdownEdits.cs
@@ -149,7 +149,12 @@ namespace PKHeX.Core.AutoMod
             }
             else
             {
-                pk.EVs = set.EVs;
+                // In Generation 1/2 Format sets, when EVs are not specified at all, it implies maximum EVs instead!
+                // Under this scenario, just apply maximum EVs (65535).
+                if (pk is GBPKM gb && set.EVs.All(z => z == 0))
+                    gb.EV_HP = gb.EV_ATK = gb.EV_DEF = gb.EV_SPC = gb.EV_SPE = gb.MaxEV;
+                else
+                    pk.EVs = set.EVs;
                 var la = new LegalityAnalysis(pk);
                 if (la.Parsed && !pk.WasEvent)
                     pk.SetRelearnMoves(la.GetSuggestedRelearnMoves());


### PR DESCRIPTION
Fixes the second noted issue for #55 and completely closes #48 

Code is copied from kwsch/PKHeX@0111c3d making it somewhat redundant, but it does fix the issue.