### PR TITLE
Smogon set importer now respects Hidden Power types

### DIFF
--- a/PKHeX.Core.Enhancements/Teams/SmogonSetList.cs
+++ b/PKHeX.Core.Enhancements/Teams/SmogonSetList.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -208,6 +208,8 @@ namespace PKHeX.Core.Enhancements
                     var move = GetMove(choice);
                     if (moves.Contains(move))
                         continue;
+                    if (move.Equals("Hidden Power", StringComparison.OrdinalIgnoreCase))
+                        move = $"{move} [{choice.Split(new[] {"\"type\":\""}, StringSplitOptions.None)[1].Split(new [] {'\"'})[0]}]";
                     moves.Add(move);
                     break;
                 }


### PR DESCRIPTION
Any Smogon Set that has Hidden Power now correctly recieves the type object

![image](https://user-images.githubusercontent.com/35675593/94735448-a3171300-031f-11eb-9f59-b366dca20411.png)
