### PR TITLE
Add optional prompts for smogon imports

### DIFF
--- a/AutoLegalityMod/GUI/ShowdownSetLoader.cs
+++ b/AutoLegalityMod/GUI/ShowdownSetLoader.cs
@@ -134,6 +134,7 @@ namespace AutoModPlugins
             APILegality.PrioritizeGame = settings.PrioritizeGame;
             APILegality.PrioritizeGameVersion = settings.PriorityGameVersion;
             Legalizer.EnableEasterEggs = settings.EnableEasterEggs;
+            SmogonGenner.PromptForImport = settings.PromptForSmogonImport;
 
             EncounterMovesetGenerator.PriorityList = settings.PrioritizeEvent
                 ? new[] {EncounterOrder.Mystery, EncounterOrder.Egg, EncounterOrder.Static, EncounterOrder.Trade, EncounterOrder.Slot}

--- a/AutoLegalityMod/GUI/ShowdownSetLoader.cs
+++ b/AutoLegalityMod/GUI/ShowdownSetLoader.cs
@@ -51,12 +51,12 @@ namespace AutoModPlugins
         /// Import Showdown Sets and alert user of any messages intended
         /// </summary>
         /// <param name="sets">Data to be loaded</param>
-        public static void Import(IReadOnlyList<ShowdownSet> sets)
+        public static void Import(IReadOnlyList<ShowdownSet> sets, bool skipDialog = false)
         {
             AutoModErrorCode result;
             if (sets.Count == 1)
             {
-                result = ImportSetToTabs(sets[0]);
+                result = ImportSetToTabs(sets[0], skipDialog);
             }
             else
             {
@@ -69,9 +69,9 @@ namespace AutoModPlugins
                 WinFormsUtil.Alert(message);
         }
 
-        private static AutoModErrorCode ImportSetToTabs(ShowdownSet set)
+        private static AutoModErrorCode ImportSetToTabs(ShowdownSet set, bool skipDialog = false)
         {
-            if (DialogResult.Yes != WinFormsUtil.Prompt(MessageBoxButtons.YesNo, "Import this set?", set.Text))
+            if (!skipDialog && DialogResult.Yes != WinFormsUtil.Prompt(MessageBoxButtons.YesNo, "Import this set?", set.Text))
                 return AutoModErrorCode.NoSingleImport;
 
             var regen = new RegenTemplate(set, SaveFileEditor.SAV.Generation);

--- a/AutoLegalityMod/Plugins/SmogonGenner.cs
+++ b/AutoLegalityMod/Plugins/SmogonGenner.cs
@@ -10,6 +10,7 @@ namespace AutoModPlugins
     {
         public override string Name => "Gen Smogon Sets";
         public override int Priority => 1;
+        public static bool PromptForImport { get; set; }
 
         protected override void AddPluginControl(ToolStripDropDownItem modmenu)
         {
@@ -46,20 +47,24 @@ namespace AutoModPlugins
                 return;
             }
 
-            for (int i = 0; i < info.Sets.Count;)
+            if (PromptForImport)
             {
-                if (DialogResult.Yes != WinFormsUtil.Prompt(MessageBoxButtons.YesNo, "Import this set?", info.SetTitle[i], info.Sets[i].Text))
+                for (int i = 0; i < info.Sets.Count;)
                 {
-                    info.Sets.RemoveAt(i);
-                    info.SetTitle.RemoveAt(i);
-                    info.SetConfig.RemoveAt(i);
-                    info.SetText.RemoveAt(i);
-                }
-                else
+                    if (DialogResult.Yes != WinFormsUtil.Prompt(MessageBoxButtons.YesNo, "Import this set?", $"[{info.SetFormat[i]}] {info.SetName[i]}", info.Sets[i].Text))
+                    {
+                        info.Sets.RemoveAt(i);
+                        info.SetFormat.RemoveAt(i);
+                        info.SetName.RemoveAt(i);
+                        info.SetConfig.RemoveAt(i);
+                        info.SetText.RemoveAt(i);
+                        continue;
+                    }
                     i++;
+                }
             }
 
-            ShowdownSetLoader.Import(info.Sets, true);
+            ShowdownSetLoader.Import(info.Sets, PromptForImport);
             WinFormsUtil.Alert(info.Summary);
         }
     }

--- a/AutoLegalityMod/Plugins/SmogonGenner.cs
+++ b/AutoLegalityMod/Plugins/SmogonGenner.cs
@@ -46,7 +46,20 @@ namespace AutoModPlugins
                 return;
             }
 
-            ShowdownSetLoader.Import(info.Sets);
+            for (int i = 0; i < info.Sets.Count;)
+            {
+                if (DialogResult.Yes != WinFormsUtil.Prompt(MessageBoxButtons.YesNo, "Import this set?", info.SetTitle[i], info.Sets[i].Text))
+                {
+                    info.Sets.RemoveAt(i);
+                    info.SetTitle.RemoveAt(i);
+                    info.SetConfig.RemoveAt(i);
+                    info.SetText.RemoveAt(i);
+                }
+                else
+                    i++;
+            }
+
+            ShowdownSetLoader.Import(info.Sets, true);
             WinFormsUtil.Alert(info.Summary);
         }
     }

--- a/AutoLegalityMod/Properties/AutoLegality.Designer.cs
+++ b/AutoLegalityMod/Properties/AutoLegality.Designer.cs
@@ -202,5 +202,17 @@ namespace AutoModPlugins.Properties {
                 this["PriorityGameVersion"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool PromptForSmogonImport {
+            get {
+                return ((bool)(this["PromptForSmogonImport"]));
+            }
+            set {
+                this["PromptForSmogonImport"] = value;
+            }
+        }
     }
 }

--- a/AutoLegalityMod/Properties/AutoLegality.settings
+++ b/AutoLegalityMod/Properties/AutoLegality.settings
@@ -47,5 +47,8 @@
     <Setting Name="PriorityGameVersion" Type="PKHeX.Core.GameVersion" Scope="User">
       <Value Profile="(Default)">Any</Value>
     </Setting>
+    <Setting Name="PromptForSmogonImport" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/AutoLegalityMod/app.config
+++ b/AutoLegalityMod/app.config
@@ -58,6 +58,9 @@
             <setting name="PriorityGameVersion" serializeAs="String">
                 <value>Any</value>
             </setting>
+            <setting name="PromptForSmogonImport" serializeAs="String">
+                <value>False</value>
+            </setting>
         </AutoModPlugins.Properties.AutoLegality>
     </userSettings>
 </configuration>

--- a/PKHeX.Core.Enhancements/Teams/SmogonSetList.cs
+++ b/PKHeX.Core.Enhancements/Teams/SmogonSetList.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -16,6 +16,7 @@ namespace PKHeX.Core.Enhancements
         public readonly string Form;
         public readonly string ShowdownSpeciesName;
         public readonly string Page;
+        public readonly List<string> SetTitle = new List<string>();
         public readonly List<string> SetConfig = new List<string>();
         public readonly List<string> SetText = new List<string>();
         public readonly List<ShowdownSet> Sets = new List<ShowdownSet>();
@@ -28,7 +29,7 @@ namespace PKHeX.Core.Enhancements
             "STABmons"            // Generates illegal movesets
         };
 
-        public string Summary => AlertText(ShowdownSpeciesName, SetText.Count, GetTitles(Page));
+        public string Summary => AlertText(ShowdownSpeciesName, SetText.Count, GetTitles());
 
         public SmogonSetList(PKM pk)
         {
@@ -77,6 +78,11 @@ namespace PKHeX.Core.Enhancements
                 if (IllegalFormats.Any(s => s.Equals(format, StringComparison.OrdinalIgnoreCase)))
                     continue;
                 var level = format.StartsWith("LC") ? 5 : 100;
+                if (!split1[i - 1].Contains("\"name\":"))
+                    continue;
+                var name = split1[i - 1].Substring(split1[i - 1].LastIndexOf("\"name\":\"", StringComparison.Ordinal) +
+                                                   "\"name\":\"".Length).Split('\"')[0];
+                SetTitle.Add($"[{format}] {name}");
                 if (!split1[i - 1].Contains("\"level\":0,") && split1[i - 1].Contains("\"level\":"))
                 {
                     int.TryParse(split1[i - 1].Split(new[] { "\"level\":" }, StringSplitOptions.None)[1]
@@ -354,27 +360,19 @@ namespace PKHeX.Core.Enhancements
             }
         }
 
-        private static Dictionary<string, List<string>> GetTitles(string pageData)
+        private Dictionary<string, List<string>> GetTitles()
         {
             var titles = new Dictionary<string, List<string>>();
-            var strats = pageData.Split(new[] { "\"strategies\":[{\"format\"" }, StringSplitOptions.None)[1].Split(new[] { "</script>" }, StringSplitOptions.None)[0];
-            var formatList = strats.Split(new[] { "\"format\"" }, StringSplitOptions.None);
-            foreach (string format in formatList)
+            foreach (string title in SetTitle)
             {
-                var key = format.Split('"')[1];
-                if (IllegalFormats.Any(s => s.Equals(key, StringComparison.OrdinalIgnoreCase)))
-                    continue;
-                var values = new List<string>();
-                // SS Smogon metadata can be dirtied by credits being flagged as team names
-                // TODO: Handle this better
-                var cleaned = format.Split(new[] { "credits" }, StringSplitOptions.None)[0];
-                var names = cleaned.Split(new[] { "\"name\"" }, StringSplitOptions.None);
-                for (int i = 1; i < names.Length; i++)
-                {
-                    values.Add(names[i].Split('"')[1]);
-                }
-                titles.Add(key, values);
+                string format = title.Substring(1, title.IndexOf("]") - 1);
+                string name = title.Substring(title.IndexOf("]") + 2);
+                if(titles.ContainsKey(format))
+                    titles[format].Add(name);
+                else
+                    titles.Add(format, new List<string>{name});
             }
+
             return titles;
         }
 

--- a/PKHeX.Core.Enhancements/Teams/SmogonSetList.cs
+++ b/PKHeX.Core.Enhancements/Teams/SmogonSetList.cs
@@ -16,7 +16,8 @@ namespace PKHeX.Core.Enhancements
         public readonly string Form;
         public readonly string ShowdownSpeciesName;
         public readonly string Page;
-        public readonly List<string> SetTitle = new List<string>();
+        public readonly List<string> SetFormat = new List<string>();
+        public readonly List<string> SetName = new List<string>();
         public readonly List<string> SetConfig = new List<string>();
         public readonly List<string> SetText = new List<string>();
         public readonly List<ShowdownSet> Sets = new List<ShowdownSet>();
@@ -82,7 +83,8 @@ namespace PKHeX.Core.Enhancements
                     continue;
                 var name = split1[i - 1].Substring(split1[i - 1].LastIndexOf("\"name\":\"", StringComparison.Ordinal) +
                                                    "\"name\":\"".Length).Split('\"')[0];
-                SetTitle.Add($"[{format}] {name}");
+                SetFormat.Add(format);
+                SetName.Add(name);
                 if (!split1[i - 1].Contains("\"level\":0,") && split1[i - 1].Contains("\"level\":"))
                 {
                     int.TryParse(split1[i - 1].Split(new[] { "\"level\":" }, StringSplitOptions.None)[1]
@@ -363,11 +365,11 @@ namespace PKHeX.Core.Enhancements
         private Dictionary<string, List<string>> GetTitles()
         {
             var titles = new Dictionary<string, List<string>>();
-            foreach (string title in SetTitle)
+            for(int i = 0; i < Sets.Count; i++)
             {
-                string format = title.Substring(1, title.IndexOf("]") - 1);
-                string name = title.Substring(title.IndexOf("]") + 2);
-                if(titles.ContainsKey(format))
+                var format = SetFormat[i];
+                var name = SetName[i];
+                if (titles.ContainsKey(format))
                     titles[format].Add(name);
                 else
                     titles.Add(format, new List<string>{name});


### PR DESCRIPTION
Old behavior:
Gather all sets for a given pokemon, import them all immediately via the showdown import function
If there is only one set, the importer asks to confirm before adding it to the tabs
If there is more than one set, the importer imports to boxes without user input

New proposed behavior:
Gather all sets for a given pokemon, prompt user for importing for each (include format and name for these sets)
If only one set is imported, the importer moves it to the tabs immediately without asking again
If more than one set are imported, they are imported to boxes without further input
If no sets are imported, don't import anything

Not sure if this behavior is better or not so I'm flagging this one as a draft