### PR TITLE
Remove unnecessary duplicate save for settings

### DIFF
--- a/AutoLegalityMod/Plugins/SettingsEditor.cs
+++ b/AutoLegalityMod/Plugins/SettingsEditor.cs
@@ -23,7 +23,6 @@ namespace AutoModPlugins
             var settings = AutoLegality.Default;
             using var form = new ALMSettings(settings);
             form.ShowDialog();
-            settings.Save();
         }
     }
 }


### PR DESCRIPTION
Very minor edit. 

Settings are already saved here: https://github.com/architdate/PKHeX-Plugins/blob/6350eea41d4f2f3690865f3f6ee18100dcd8cd07/AutoLegalityMod/GUI/ALMSettings.cs#L23-L29

Saving twice is redundant. Tested and confirmed that settings changes still persist between sessions.