### PR TITLE
Add option for Legalizer to set Battle Version for Pokemon who meet the criteria

### DIFF
--- a/AutoLegalityMod/GUI/ShowdownSetLoader.cs
+++ b/AutoLegalityMod/GUI/ShowdownSetLoader.cs
@@ -133,6 +133,7 @@ namespace AutoModPlugins
             APILegality.SetRandomTracker = settings.SetRandomTracker;
             APILegality.PrioritizeGame = settings.PrioritizeGame;
             APILegality.PrioritizeGameVersion = settings.PriorityGameVersion;
+            APILegality.SetBattleVersion = settings.SetBattleVersion;
             Legalizer.EnableEasterEggs = settings.EnableEasterEggs;
             SmogonGenner.PromptForImport = settings.PromptForSmogonImport;
 

--- a/AutoLegalityMod/Properties/AutoLegality.Designer.cs
+++ b/AutoLegalityMod/Properties/AutoLegality.Designer.cs
@@ -214,5 +214,17 @@ namespace AutoModPlugins.Properties {
                 this["PromptForSmogonImport"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool SetBattleVersion {
+            get {
+                return ((bool)(this["SetBattleVersion"]));
+            }
+            set {
+                this["SetBattleVersion"] = value;
+            }
+        }
     }
 }

--- a/AutoLegalityMod/Properties/AutoLegality.settings
+++ b/AutoLegalityMod/Properties/AutoLegality.settings
@@ -50,5 +50,8 @@
     <Setting Name="PromptForSmogonImport" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="SetBattleVersion" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/AutoLegalityMod/app.config
+++ b/AutoLegalityMod/app.config
@@ -61,6 +61,9 @@
             <setting name="PromptForSmogonImport" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="SetBattleVersion" serializeAs="String">
+                <value>True</value>
+            </setting>
         </AutoModPlugins.Properties.AutoLegality>
     </userSettings>
 </configuration>

--- a/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
@@ -377,7 +377,7 @@ namespace PKHeX.Core.AutoMod
         {
             if (SetBattleVersion && !pk.IsNative && pk is IBattleVersion bvPk)
             {
-                int oldBattleVersion = bvPk.BattleVersion;
+                var oldBattleVersion = bvPk.BattleVersion;
                 bvPk.BattleVersion = trainer.Game;
 
                 var la = new LegalityAnalysis(pk);

--- a/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
@@ -373,6 +373,11 @@ namespace PKHeX.Core.AutoMod
             }
         }
 
+        /// <summary>
+        /// Sets past-generation Pokemon as Battle Ready for games that support it
+        /// </summary>
+        /// <param name="pk">Return PKM</param>
+        /// <param name="trainer">Trainer to handle the <see cref="pk"/></param>
         private static void ApplyBattleVersion(this PKM pk, ITrainerInfo trainer)
         {
             if (SetBattleVersion && !pk.IsNative && pk is IBattleVersion bvPk)

--- a/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
@@ -206,7 +206,7 @@ namespace PKHeX.Core.AutoMod
             pk.SetSuggestedBall(SetMatchingBalls, ForceSpecifiedBall, set is RegenTemplate b ? b.Ball : Ball.None);
             pk.ApplyMarkings(UseMarkings, UseCompetitiveMarkings);
             pk.ApplyHeightWeight(enc);
-            pk.ApplyBattleVersion();
+            pk.ApplyBattleVersion(handler);
 
             // Extra legality unchecked by PKHeX
             pk.SetDatelocks(enc);
@@ -373,19 +373,18 @@ namespace PKHeX.Core.AutoMod
             }
         }
 
-        private static void ApplyBattleVersion(this PKM pk)
+        private static void ApplyBattleVersion(this PKM pk, ITrainerInfo trainer)
         {
-            if (SetBattleVersion && !pk.IsNative && pk is PK8 pk8)
+            if (SetBattleVersion && !pk.IsNative && pk is IBattleVersion bvPk)
             {
-                PK8 clone = (PK8)pk8.Clone();
-                clone.BattleVersion = (int)GameVersion.SW;
+                int oldBattleVersion = bvPk.BattleVersion;
+                bvPk.BattleVersion = trainer.Game;
 
-                var la = new LegalityAnalysis(clone);
+                var la = new LegalityAnalysis(pk);
                 if (la.Info.Moves.All(z => z.Valid))
-                {
-                    pk8.ClearRelearnMoves();
-                    pk8.BattleVersion = (int)GameVersion.SW;
-                }
+                    pk.ClearRelearnMoves();
+                else
+                    bvPk.BattleVersion = oldBattleVersion;
             }
         }
 

--- a/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
@@ -22,6 +22,7 @@ namespace PKHeX.Core.AutoMod
         public static bool PrioritizeGame { get; set; } = true;
         public static bool SetRandomTracker { get; set; }
         public static GameVersion PrioritizeGameVersion { get; set; }
+        public static bool SetBattleVersion { get; set; }
 
         /// <summary>
         /// Main function that auto legalizes based on the legality
@@ -205,6 +206,7 @@ namespace PKHeX.Core.AutoMod
             pk.SetSuggestedBall(SetMatchingBalls, ForceSpecifiedBall, set is RegenTemplate b ? b.Ball : Ball.None);
             pk.ApplyMarkings(UseMarkings, UseCompetitiveMarkings);
             pk.ApplyHeightWeight(enc);
+            pk.ApplyBattleVersion();
 
             // Extra legality unchecked by PKHeX
             pk.SetDatelocks(enc);
@@ -368,6 +370,22 @@ namespace PKHeX.Core.AutoMod
                 default:
                     pk.Version = original.Version;
                     break;
+            }
+        }
+
+        private static void ApplyBattleVersion(this PKM pk)
+        {
+            if (SetBattleVersion && !pk.IsNative && pk is PK8 pk8)
+            {
+                PK8 clone = (PK8)pk8.Clone();
+                clone.BattleVersion = (int)GameVersion.SW;
+
+                var la = new LegalityAnalysis(clone);
+                if (la.Info.Moves.All(z => z.Valid))
+                {
+                    pk8.ClearRelearnMoves();
+                    pk8.BattleVersion = (int)GameVersion.SW;
+                }
             }
         }
 


### PR DESCRIPTION
Adds an option that, when enabled, will set a past-gen PK8's Battle Version assuming the Pokemon's moveset would still be legal. If the Pokemon's learnset would not be legal with a Battle Version set, this option does nothing.

With the option enabled: https://gfycat.com/SelfreliantFearfulIndianhare
With the option disabled: https://gfycat.com/WaryPleasingClownanemonefish

Currently on by default, though this can be changed.