### PR TITLE
Add support for pokemon unobtainable in Gen 2 for Living Dex

### DIFF
--- a/PKHeX.Core.AutoMod/Enhancements/ModLogic.cs
+++ b/PKHeX.Core.AutoMod/Enhancements/ModLogic.cs
@@ -68,7 +68,7 @@ namespace PKHeX.Core.AutoMod
                     pk.Heal();
                     yield return pk;
                 }
-                else if (sav is SAV2 && GetRandomEncounter(new SAV1(GameVersion.Y){Language = sav.Language, OT = sav.OT, TID = sav.TID}, id, out var pkm) && pkm is PK1 pk1 && pk1 != null)
+                else if (sav is SAV2 && GetRandomEncounter(new SAV1(GameVersion.Y){Language = sav.Language, OT = sav.OT, TID = sav.TID}, id, out var pkm) && pkm is PK1 pk1)
                 {
                     yield return pk1.ConvertToPK2();
                 }

--- a/PKHeX.Core.AutoMod/Enhancements/ModLogic.cs
+++ b/PKHeX.Core.AutoMod/Enhancements/ModLogic.cs
@@ -68,6 +68,10 @@ namespace PKHeX.Core.AutoMod
                     pk.Heal();
                     yield return pk;
                 }
+                else if (sav is SAV2 && GetRandomEncounter(new SAV1(GameVersion.Y){Language = sav.Language, OT = sav.OT, TID = sav.TID}, id, out var pkm) && pkm is PK1 pk1 && pk1 != null)
+                {
+                    yield return pk1.ConvertToPK2();
+                }
             }
         }
 


### PR DESCRIPTION
For pokemon that do not have valid encounters in Generation 2, generates Generation 1 encounters to complete the dex.