### PR TITLE
Properly import Gmax via smogon importer

### DIFF
--- a/PKHeX.Core.Enhancements/Teams/SmogonSetList.cs
+++ b/PKHeX.Core.Enhancements/Teams/SmogonSetList.cs
@@ -71,6 +71,7 @@ namespace PKHeX.Core.Enhancements
             for (int i = 1; i < split1.Length; i++)
             {
                 var shiny = split1[i - 1].Contains("\"shiny\":true");
+                var setSpecies = split1[i-1].Substring(split1[i - 1].IndexOf("\"pokemon\":\"", StringComparison.Ordinal) + "\"pokemon\":\"".Length).Split('\"')[0];
                 if (split1[i - 1].Contains("\"format\":\""))
                 {
                     format = split1[i - 1]
@@ -99,7 +100,7 @@ namespace PKHeX.Core.Enhancements
                 var tmp = split2[0];
                 SetConfig.Add(tmp);
 
-                var morphed = ConvertSetToShowdown(tmp, ShowdownSpeciesName, shiny, level);
+                var morphed = ConvertSetToShowdown(tmp, setSpecies, shiny, level);
                 SetText.Add(morphed);
 
                 var converted = new ShowdownSet(morphed);

--- a/PKHeX.Core.Enhancements/Teams/SmogonSetList.cs
+++ b/PKHeX.Core.Enhancements/Teams/SmogonSetList.cs
@@ -71,7 +71,7 @@ namespace PKHeX.Core.Enhancements
             for (int i = 1; i < split1.Length; i++)
             {
                 var shiny = split1[i - 1].Contains("\"shiny\":true");
-                var setSpecies = split1[i-1].Substring(split1[i - 1].IndexOf("\"pokemon\":\"", StringComparison.Ordinal) + "\"pokemon\":\"".Length).Split('\"')[0];
+                var setSpecies = split1[i-1].Substring(split1[i - 1].LastIndexOf("\"pokemon\":\"", StringComparison.Ordinal) + "\"pokemon\":\"".Length).Split('\"')[0];
                 if (split1[i - 1].Contains("\"format\":\""))
                 {
                     format = split1[i - 1]

--- a/PKHeX.Core.Enhancements/Teams/SmogonSetList.cs
+++ b/PKHeX.Core.Enhancements/Teams/SmogonSetList.cs
@@ -71,7 +71,6 @@ namespace PKHeX.Core.Enhancements
             for (int i = 1; i < split1.Length; i++)
             {
                 var shiny = split1[i - 1].Contains("\"shiny\":true");
-                var setSpecies = split1[i-1].Substring(split1[i - 1].LastIndexOf("\"pokemon\":\"", StringComparison.Ordinal) + "\"pokemon\":\"".Length).Split('\"')[0];
                 if (split1[i - 1].Contains("\"format\":\""))
                 {
                     format = split1[i - 1]
@@ -88,6 +87,7 @@ namespace PKHeX.Core.Enhancements
                     continue;
                 var name = split1[i - 1].Substring(split1[i - 1].LastIndexOf("\"name\":\"", StringComparison.Ordinal) +
                                                    "\"name\":\"".Length).Split('\"')[0];
+                var setSpecies = split1[i - 1].Substring(split1[i - 1].LastIndexOf("\"pokemon\":\"", StringComparison.Ordinal) + "\"pokemon\":\"".Length).Split('\"')[0];
                 SetFormat.Add(format);
                 SetName.Add(name);
                 if (!split1[i - 1].Contains("\"level\":0,") && split1[i - 1].Contains("\"level\":"))


### PR DESCRIPTION
Now properly imports pokemon with the "-GMax" identifier on their showdown export as Gigantamax pokemon. Replaces/invalidates the implementation of #75 