### PR TITLE
add missing -UseBasicParsing to setup scripts

### DIFF
--- a/setup_bleedingedge.ps1
+++ b/setup_bleedingedge.ps1
@@ -45,10 +45,10 @@ Write-Host "Downloading latest PKHeX Build (latest) from https://projectpokemon.
 Invoke-WebRequest $url -OutFile "PKHeX.zip" -Headers $headers -WebSession $session -Method Get -ContentType "application/zip" -UseBasicParsing
 
 # get latest plugins build
-$j = Invoke-WebRequest 'https://dev.azure.com/architdate/40cccbb5-1611-4da1-aa70-c9cc0fba36e2/_apis/build/builds?definitions=1&$top=1&resultFilter=succeeded&api-version=6.0' | ConvertFrom-Json
+$j = Invoke-WebRequest 'https://dev.azure.com/architdate/40cccbb5-1611-4da1-aa70-c9cc0fba36e2/_apis/build/builds?definitions=1&$top=1&resultFilter=succeeded&api-version=6.0' -UseBasicParsing | ConvertFrom-Json
 $buildid = $j.value.id
 $aurl = "https://dev.azure.com/architdate/40cccbb5-1611-4da1-aa70-c9cc0fba36e2/_apis/build/builds/$buildid/artifacts?artifactName=PKHeX-Plugins&api-version=6.0"
-$a = Invoke-WebRequest $aurl | ConvertFrom-Json
+$a = Invoke-WebRequest $aurl -UseBasicParsing | ConvertFrom-Json
 $download = $a.resource.downloadUrl
 $file = "PKHeX-Plugins.zip"
 

--- a/setup_stable.ps1
+++ b/setup_stable.ps1
@@ -50,7 +50,7 @@ $file = "PKHeX-Plugins.zip"
 $releases = "https://api.github.com/repos/$pluginsrepo/releases"
 
 Write-Host "Determining latest plugin release ..."
-$tag = (Invoke-WebRequest $releases | ConvertFrom-Json)[0].tag_name
+$tag = (Invoke-WebRequest $releases -UseBasicParsing | ConvertFrom-Json)[0].tag_name
 
 # download as PKHeX-Plugins.zip
 Write-Host Downloading latest PKHeX-Plugin Release: $tag


### PR DESCRIPTION
`-UseBasicParsing` should be used to support user which are on a windows version which doesn't have Internet Explorer engine  installed and it was missing on some requests 👍 