### PR TITLE
Niche Competitive Fix

### DIFF
--- a/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
@@ -386,7 +386,7 @@ namespace PKHeX.Core.AutoMod
             // Fix HT flags as necessary
             t.HT_ATK = (set.IVs[1] >= 3 || !t.HT_ATK) && ((set.IVs[1] >= 3 && pk.IVs[1] < 3 && pk.CurrentLevel == 100) || t.HT_ATK);
             t.HT_SPE = (set.IVs[3] >= 3 || !t.HT_SPE) && ((set.IVs[3] >= 3 && pk.IVs[3] < 3 && pk.CurrentLevel == 100) || t.HT_SPE);
-            t.HT_SPA = (set.IVs[4] >= 4 || !t.HT_SPA) && ((set.IVs[4] >= 4 && pk.IVs[4] < 4 && pk.CurrentLevel == 100) || t.HT_SPA);
+            t.HT_SPA = (set.IVs[4] >= 3 || !t.HT_SPA) && ((set.IVs[4] >= 3 && pk.IVs[4] < 3 && pk.CurrentLevel == 100) || t.HT_SPA);
 
             // Handle special cases here for ultrabeasts
             switch (pk.Species)

--- a/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
@@ -386,6 +386,7 @@ namespace PKHeX.Core.AutoMod
             // Fix HT flags as necessary
             t.HT_ATK = (set.IVs[1] >= 3 || !t.HT_ATK) && ((set.IVs[1] >= 3 && pk.IVs[1] < 3 && pk.CurrentLevel == 100) || t.HT_ATK);
             t.HT_SPE = (set.IVs[3] >= 3 || !t.HT_SPE) && ((set.IVs[3] >= 3 && pk.IVs[3] < 3 && pk.CurrentLevel == 100) || t.HT_SPE);
+            t.HT_SPA = (set.IVs[4] >= 4 || !t.HT_SPA) && ((set.IVs[4] >= 4 && pk.IVs[4] < 4 && pk.CurrentLevel == 100) || t.HT_SPA);
 
             // Handle special cases here for ultrabeasts
             switch (pk.Species)


### PR DESCRIPTION
Fix for hyper training special attack when specified 0-3
Allows for niche sets that utilize attacking a friendly pokemon ie. Surf Dragapult on a friendly Coalossal for WP proc
Uses same logic as Atk & Spe