### PR TITLE
Allow USB port specification in order to connect to a specific USB device.

### DIFF
--- a/AutoLegalityMod/GUI/LiveHexUI.cs
+++ b/AutoLegalityMod/GUI/LiveHexUI.cs
@@ -279,7 +279,7 @@ namespace AutoModPlugins
 
         private void SetInjectionTypeView()
         {
-            TB_IP.Visible = TB_Port.Visible = L_IP.Visible = L_Port.Visible = CurrentInjectionType == InjectorCommunicationType.SocketNetwork;
+            TB_IP.Visible = L_IP.Visible = CurrentInjectionType == InjectorCommunicationType.SocketNetwork;
             L_USBState.Visible = CurrentInjectionType == InjectorCommunicationType.USB;
         }
 

--- a/PKHeX.Core.Injection/BotController/Controllers/UsbBotMini.cs
+++ b/PKHeX.Core.Injection/BotController/Controllers/UsbBotMini.cs
@@ -35,7 +35,8 @@ namespace PKHeX.Core.Injection
                 // Find and open the usb device.
                 foreach (UsbRegistry ur in UsbDevice.AllDevices)
                 {
-                    if (ur.Vid == 1406 && ur.Pid == 12288)
+                    ur.DeviceProperties.TryGetValue("Address", out object port);
+                    if (ur.Vid == 1406 && ur.Pid == 12288 && Port == (int)port)
                         SwDevice = ur.Device;
                 }
                 //SwDevice = UsbDevice.OpenUsbDevice(MyUsbFinder);


### PR DESCRIPTION
LiveHex currently connects to the first USB device it finds, which is rarely desirable in an environment where multiple Switches are connected via USB.
These small changes allow a user to specify a USB port they'd like to connect to by leaving the "Port" box visible and filtering out USB ports that don't match the input. USB port can be obtained as outlined in USB-Botbase's setup guide in SysBot's wiki.