### PR TITLE
[Smogon Import] Add proper handling for Sirfetch'd and Indeedee

### DIFF
--- a/PKHeX.Core.Enhancements/Teams/SmogonSetList.cs
+++ b/PKHeX.Core.Enhancements/Teams/SmogonSetList.cs
@@ -244,6 +244,7 @@ namespace PKHeX.Core.Enhancements
                 "Nidoran♀" => "nidoran-f",
                 "Farfetch’d" => "farfetchd",
                 "Flabébé" => "flabebe",
+                "Sirfetch’d" => "sirfetchd",
                 _ => spec,
             };
         }
@@ -258,6 +259,7 @@ namespace PKHeX.Core.Enhancements
                 "Oricorio" when form == "Pa’u" => "pau",
                 "Darmanitan" when form == "Galarian Standard" => "galar",
                 "Meowstic" when form.Length == 0 => "m",
+                "Indeedee" when form.Length == 0 => "m",
                 "Gastrodon" => "",
                 "Vivillon" => "",
                 "Sawsbuck" => "",


### PR DESCRIPTION
Simple fix to match similar implementations for Farfetch'd and Meowstic. Fixes URL error when genning sets for Sirfetch'd.