### PR TITLE
Fix Indeedee-M smogon import

### DIFF
--- a/PKHeX.Core.Enhancements/Teams/SmogonSetList.cs
+++ b/PKHeX.Core.Enhancements/Teams/SmogonSetList.cs
@@ -259,7 +259,6 @@ namespace PKHeX.Core.Enhancements
                 "Oricorio" when form == "Pa’u" => "pau",
                 "Darmanitan" when form == "Galarian Standard" => "galar",
                 "Meowstic" when form.Length == 0 => "m",
-                "Indeedee" when form.Length == 0 => "m",
                 "Gastrodon" => "",
                 "Vivillon" => "",
                 "Sawsbuck" => "",


### PR DESCRIPTION
Indeedee-M uses the base URL on Smogon, unlike Meowstic. Honestly not sure how I didn't catch this, my bad