### PR TITLE
Add build timestamp and build version to `Directory.Build.props`.

### DIFF
--- a/AutoLegalityMod/GUI/ALMError.Designer.cs
+++ b/AutoLegalityMod/GUI/ALMError.Designer.cs
@@ -122,7 +122,7 @@
             this.Text = "ALMError";
             this.ResumeLayout(false);
             this.PerformLayout();
-
+            this.BringToFront();
         }
 
         #endregion

--- a/AutoLegalityMod/GUI/ALMError.cs
+++ b/AutoLegalityMod/GUI/ALMError.cs
@@ -1,11 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
 using System.Drawing;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace AutoModPlugins.GUI
@@ -24,7 +19,7 @@ namespace AutoModPlugins.GUI
             buttons = buttons.Reverse().ToArray();
             var btn_loc = label1.Location.Y + label1.Size.Height + 10;
             var height_diff = btn_loc - BTN1.Location.Y;
-            for (int i = 0; i < buttons.Count(); i++)
+            for (int i = 0; i < buttons.Length; i++)
             {
                 btn_ctrls[i].Visible = true;
                 btn_ctrls[i].Enabled = true;

--- a/AutoLegalityMod/GUI/ShowdownSetLoader.cs
+++ b/AutoLegalityMod/GUI/ShowdownSetLoader.cs
@@ -95,7 +95,7 @@ namespace AutoModPlugins
             if (msg is LegalizationResult.VersionMismatch)
             {
                 var errorstr = "The PKHeX-Plugins version does not match the PKHeX version.\n\nRefer to the Wiki to fix this error.";
-                var res = WinFormsUtil.ALMErrorBasic(errorstr, $"The current ALM Version is {ALMVersion.CurrentALMVersion}\nThe current PKHeX Version is {ALMVersion.CurrentPKHeXVersion}");
+                var res = WinFormsUtil.ALMErrorBasic(errorstr, $"The current ALM Version is {ALMVersion.GetCurrentVersion("PKHeX.Core.AutoMod")}\nThe current PKHeX Version is {ALMVersion.GetCurrentVersion("PKHeX.Core")}");
                 if (res == DialogResult.Retry)
                     Process.Start(new ProcessStartInfo { FileName = "https://github.com/architdate/PKHeX-Plugins/wiki/Installing-PKHeX-Plugins", UseShellExecute = true });
                 return AutoModErrorCode.VersionMismatch;
@@ -153,7 +153,7 @@ namespace AutoModPlugins
             if (result is AutoModErrorCode.VersionMismatch)
             {
                 var errorstr = "The PKHeX-Plugins version does not match the PKHeX version. \nRefer to the Wiki for how to fix this error.";
-                var res = WinFormsUtil.ALMErrorBasic(errorstr, $"The current ALM Version is {ALMVersion.CurrentALMVersion}\nThe current PKHeX Version is {ALMVersion.CurrentPKHeXVersion}");
+                var res = WinFormsUtil.ALMErrorBasic(errorstr, $"The current ALM Version is {ALMVersion.GetCurrentVersion("PKHeX.Core.AutoMod")}\nThe current PKHeX Version is {ALMVersion.GetCurrentVersion("PKHeX.Core")}");
                 if (res == DialogResult.Retry)
                     Process.Start(new ProcessStartInfo { FileName = "https://github.com/architdate/PKHeX-Plugins/wiki/Installing-PKHeX-Plugins", UseShellExecute = true });
                 return AutoModErrorCode.VersionMismatch;

--- a/AutoLegalityMod/Plugins/AutoModPlugin.cs
+++ b/AutoLegalityMod/Plugins/AutoModPlugin.cs
@@ -73,8 +73,8 @@ namespace AutoModPlugins
         private void CheckVersionUpdates()
         {
             var latest_alm = PKHeX.Core.AutoMod.NetUtil.GetLatestALMVersion();
-            var curr_alm = ALMVersion.CurrentALMVersion;
-            var curr_pkhex = ALMVersion.CurrentPKHeXVersion;
+            var curr_alm = ALMVersion.GetCurrentVersion("PKHeX.Core.AutoMod");
+            var curr_pkhex = ALMVersion.GetCurrentVersion("PKHeX.Core");
             if (curr_alm == null || curr_pkhex == null || latest_alm == null)
                 return;
 

--- a/AutoLegalityMod/Plugins/LegalizeBoxes.cs
+++ b/AutoLegalityMod/Plugins/LegalizeBoxes.cs
@@ -40,7 +40,7 @@ namespace AutoModPlugins
             catch (MissingMethodException)
             {
                 var errorstr = "The PKHeX-Plugins version does not match the PKHeX version. \nRefer to the Wiki for how to fix this error.";
-                var res = WinFormsUtil.ALMErrorBasic(errorstr, $"The current ALM Version is {ALMVersion.CurrentALMVersion}\nThe current PKHeX Version is {ALMVersion.CurrentPKHeXVersion}");
+                var res = WinFormsUtil.ALMErrorBasic(errorstr, $"The current ALM Version is {ALMVersion.GetCurrentVersion("PKHeX.Core.AutoMod")}\nThe current PKHeX Version is {ALMVersion.GetCurrentVersion("PKHeX.Core")}");
                 if (res == DialogResult.Retry)
                     Process.Start(new ProcessStartInfo { FileName = "https://github.com/architdate/PKHeX-Plugins/wiki/Installing-PKHeX-Plugins", UseShellExecute = true });
             }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,10 @@
 <Project>
   <PropertyGroup>
-	<TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
+    <Version>23.01.30</Version>
     <LangVersion>11</LangVersion>
     <Nullable>enable</Nullable>
     <NeutralLanguage>en</NeutralLanguage>
+    <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Core.AutoMod/AutoMod/Trainers/TrainerSettings.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/Trainers/TrainerSettings.cs
@@ -10,7 +10,7 @@ namespace PKHeX.Core.AutoMod
     public static class TrainerSettings
     {
         private static readonly TrainerDatabase Database = new();
-        private static readonly string TrainerPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "trainers");
+        private static readonly string TrainerPath = Path.Combine(Path.GetDirectoryName(Environment.ProcessPath)!, "trainers");
         private static readonly SimpleTrainerInfo DefaultFallback8 = new(GameVersion.SW);
         private static readonly SimpleTrainerInfo DefaultFallback7 = new(GameVersion.UM);
         private static readonly GameVersion[] FringeVersions = { GameVersion.GG, GameVersion.BDSP, GameVersion.PLA };

--- a/PKHeX.Core.AutoMod/AutoMod/Util/Version.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/Util/Version.cs
@@ -1,28 +1,17 @@
 ﻿using System;
+using System.Linq;
 using System.Reflection;
 
 namespace PKHeX.Core.AutoMod
 {
     public static class ALMVersion
-
     {
-        public const string CurrentVersion = "23.01.30";
+        private static readonly Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
 
-        /*
-         * TODO: Add other versioning code, maybe compatability lists here?
-         */
-
-        public static Version? CurrentPKHeXVersion
+        public static Version? GetCurrentVersion(string assemblyName)
         {
-            get
-            {
-                Version? version = Assembly.GetEntryAssembly()?.GetName().Version;
-                if (version == null)
-                    return null;
-                return new Version(version.Major, version.Minor, version.Build);
-            }
+            var assembly = assemblies.FirstOrDefault(x => x.GetName().Name == assemblyName);
+            return assembly?.GetName().Version;
         }
-        public static Version? CurrentALMVersion => Version.TryParse(CurrentVersion, out var current_alm) ? current_alm : null;
-
     }
 }


### PR DESCRIPTION
Bring ALM error to front.
Change versioning code.
Fix `trainers` folder.