### PR TITLE
Fix setting HW scalar when not intended

### DIFF
--- a/AutoModTests/ShowdownSets/Anubis Tests/Anubis - pk9.txt
+++ b/AutoModTests/ShowdownSets/Anubis Tests/Anubis - pk9.txt
@@ -907,7 +907,7 @@ Ball: Master Ball
 - X-Scissor
 - Swords Dance
 
-Tauros-Paldea (M)
+Tauros-Paldea-Combat (M)
 IVs: 29 HP / 21 Atk / 15 Def / 1 SpA / 21 SpD / 28 Spe
 Ability: Intimidate
 Tera Type: Fighting
@@ -922,7 +922,7 @@ Ball: Master Ball
 - Headbutt
 - Scary Face
 
-Tauros-Paldea (M)
+Tauros-Paldea-Combat (M)
 IVs: 17 HP / 18 Atk / 7 Def / 9 SpA / 18 SpD / 9 Spe
 Ability: Intimidate
 Tera Type: Fighting
@@ -937,7 +937,7 @@ Ball: Master Ball
 - Assurance
 - Headbutt
 
-Tauros-Paldea (M)
+Tauros-Paldea-Blaze (M)
 IVs: 26 SpD
 Ability: Cud Chew
 Tera Type: Fire
@@ -951,7 +951,7 @@ Docile Nature
 - Zen Headbutt
 - Raging Bull
 
-Tauros-Paldea (M)
+Tauros-Paldea-Combat (M)
 IVs: 30 HP / 2 Atk / 26 Def / 16 SpA / 14 SpD / 3 Spe
 Ability: Intimidate
 Tera Type: Fighting
@@ -9305,3 +9305,25 @@ Adamant Nature
 - Bulk Up
 - Collision Course
 - Flamethrower
+
+Walking Wake
+IVs: 30 Def / 22 Spe
+Ability: Protosynthesis
+Tera Type: Water
+Level: 75
+Hasty Nature
+.Met_Location=30024
+~=Generation=9
+- Hydro Steam
+- Dragon Pulse
+- Noble Roar
+- Flamethrower
+
+Pikachu
+.Met_Location=40001
+~=Generation=9
+- Fly
+
+Pikachu
+~=Generation=9
+.RibbonMarkMightiest=True

--- a/AutoModTests/ShowdownSets/RoCs-PC Tests/RoC - pk9.txt
+++ b/AutoModTests/ShowdownSets/RoCs-PC Tests/RoC - pk9.txt
@@ -660,7 +660,7 @@ Ball: Master Ball
 - X-Scissor
 - Swords Dance
 
-Tauros-Paldea (M)
+Tauros-Paldea-Combat (M)
 IVs: 22 HP / 22 Atk / 2 Def / 29 SpA / 25 SpD / 12 Spe
 Ability: Anger Point
 Tera Type: Fighting
@@ -674,7 +674,7 @@ Modest Nature
 - Assurance
 - Headbutt
 
-Tauros-Paldea-Fire (M)
+Tauros-Paldea-Blaze (M)
 IVs: 30 HP / 13 Atk / 15 Def / 10 SpA / 24 SpD
 Ability: Anger Point
 Tera Type: Fighting
@@ -689,7 +689,7 @@ Ball: Master Ball
 - Headbutt
 - Scary Face
 
-Tauros-Paldea-Water (M)
+Tauros-Paldea-Aqua (M)
 IVs: 6 HP / 0 Atk / 9 Def / 24 SpA / 5 SpD / 25 Spe
 Ability: Intimidate
 Tera Type: Fighting

--- a/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
@@ -392,7 +392,7 @@ namespace PKHeX.Core.AutoMod
         public static bool IsPIDIVSet(PKM pk, IEncounterable enc)
         {
             // If PID and IV is handled in PreSetPIDIV, don't set it here again and return out
-            if (enc is EncounterTera9 or EncounterDist9 or EncounterMight9)
+            if (enc is ITeraRaid9)
                 return true;
             if (enc is EncounterStatic8N or EncounterStatic8NC or EncounterStatic8ND or EncounterStatic8U)
                 return true;

--- a/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
@@ -392,7 +392,7 @@ namespace PKHeX.Core.AutoMod
         public static bool IsPIDIVSet(PKM pk, IEncounterable enc)
         {
             // If PID and IV is handled in PreSetPIDIV, don't set it here again and return out
-            if (enc is EncounterTera9)
+            if (enc is EncounterTera9 or EncounterDist9 or EncounterMight9)
                 return true;
             if (enc is EncounterStatic8N or EncounterStatic8NC or EncounterStatic8ND or EncounterStatic8U)
                 return true;
@@ -673,7 +673,9 @@ namespace PKHeX.Core.AutoMod
             if (IsPIDIVSet(pk, enc) && !changeec)
                 return;
 
-            if (changeec) pk.SetRandomEC(); // break correlation
+            if (changeec)
+                pk.SetRandomEC(); // break correlation
+
             if (enc is MysteryGift mg)
             {
                 var ivs = pk.IVs;

--- a/PKHeX.Core.AutoMod/AutoMod/Legalization/ShowdownEdits.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/Legalization/ShowdownEdits.cs
@@ -46,7 +46,7 @@ namespace PKHeX.Core.AutoMod
             if (pk.Nature == set.Nature || set.Nature == -1)
                 return;
             var val = Math.Min((int)Nature.Quirky, Math.Max((int)Nature.Hardy, set.Nature));
-            if (pk.Species == (int)Species.Toxtricity)
+            if (pk.Species == (ushort)Species.Toxtricity)
             {
                 if (pk.Form == EvolutionMethod.GetAmpLowKeyResult(val))
                     pk.Nature = val; // StatNature already set

--- a/PKHeX.Core.AutoMod/AutoMod/Legalization/SimpleEdits.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/Legalization/SimpleEdits.cs
@@ -150,7 +150,7 @@ namespace PKHeX.Core.AutoMod
                 return;
             }
 
-            if (enc is not ITeraRaid9 && ((pk.Species == (int)Maushold && pk.Form == 0) || (pk.Species == (int)Dudunsparce && pk.Form == 1)))
+            if (enc is not ITeraRaid9 && ((pk.Species == (ushort)Maushold && pk.Form == 0) || (pk.Species == (ushort)Dudunsparce && pk.Form == 1)))
             {
                 pk.EncryptionConstant = pk.EncryptionConstant / 100 * 100;
                 return;
@@ -316,7 +316,15 @@ namespace PKHeX.Core.AutoMod
             if (enc is WC8 w8)
             {
                 var isHOMEGift = w8.Location == 30018 || w8.GetOT(2) == "HOME";
-                if (isHOMEGift) return;
+                if (isHOMEGift)
+                    return;
+            }
+
+            if (enc is WC9 wc9)
+            {
+                size.WeightScalar = (byte)wc9.WeightValue;
+                size.HeightScalar= (byte)wc9.HeightValue;
+                return;
             }
 
             if (APILegality.IsPIDIVSet(pk, enc) && !(enc is EncounterStatic8N or EncounterStatic8NC or EncounterStatic8ND) && !(enc is EncounterEgg && GameVersion.BDSP.Contains(enc.Version)))


### PR DESCRIPTION
Fix Walking Wake, Iron Leaves, MightiestMark and Fly Pikachu, fix Tauros-Paldea test sets, add more sets.