### PR TITLE
Living dex fixes

### DIFF
--- a/AutoLegalityMod/GUI/ALMSettings.cs
+++ b/AutoLegalityMod/GUI/ALMSettings.cs
@@ -37,6 +37,7 @@ namespace AutoModPlugins.GUI
             new("IncludeForms", "Generate all forms of the Pokémon. Note that some generations may not have enough box space for all forms.", "Living Dex"),
             new("SetShiny", "Try to generate the shiny version of the Pokémon if possible.", "Living Dex"),
             new("SetAlpha", "Try to generate the alpha version of the Pokémon if possible.", "Living Dex"),
+            new("NativeOnly", "Only generate Pokémon natively available in the game version pair.", "Living Dex"),
 
             // Miscellaneous
             new("GPSSBaseURL", "Base URL for Flagbrew's Global PKSM Sharing Service (GPSS) features.", "Miscellaneous"),

--- a/AutoLegalityMod/GUI/ShowdownSetLoader.cs
+++ b/AutoLegalityMod/GUI/ShowdownSetLoader.cs
@@ -192,6 +192,7 @@ namespace AutoModPlugins
             ModLogic.IncludeForms = settings.IncludeForms;
             ModLogic.SetShiny = settings.SetShiny;
             ModLogic.SetAlpha = settings.SetAlpha;
+            ModLogic.NativeOnly = settings.NativeOnly;
 
             if (APILegality.UseCompetitiveMarkings)
                 MarkingApplicator.MarkingMethod = APILegality.CompetitiveMarking;

--- a/AutoLegalityMod/Plugins/LivingDex.cs
+++ b/AutoLegalityMod/Plugins/LivingDex.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Windows.Forms;
 using AutoModPlugins.Properties;
 using PKHeX.Core;
@@ -26,13 +27,13 @@ namespace AutoModPlugins
                 return;
 
             var sav = SaveFileEditor.SAV;
-            var pkms = sav.GenerateLivingDex(out int attempts);
+            var pkms = sav.GenerateLivingDex().ToArray();
             var bd = sav.BoxData;
             pkms.CopyTo(bd);
             sav.BoxData = bd;
             SaveFileEditor.ReloadSlots();
 
-            System.Diagnostics.Debug.WriteLine($"Generated Living Dex after {attempts} attempts.");
+            System.Diagnostics.Debug.WriteLine($"Generated Living Dex with {pkms.Length} entries.");
         }
     }
 }

--- a/AutoLegalityMod/Properties/AutoLegality.Designer.cs
+++ b/AutoLegalityMod/Properties/AutoLegality.Designer.cs
@@ -12,7 +12,7 @@ namespace AutoModPlugins.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.1.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.4.0.0")]
     internal sealed partial class AutoLegality : global::System.Configuration.ApplicationSettingsBase {
         
         private static AutoLegality defaultInstance = ((AutoLegality)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new AutoLegality())));
@@ -118,7 +118,7 @@ namespace AutoModPlugins.Properties {
                 this["LatestIP"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("6000")]
@@ -287,6 +287,18 @@ namespace AutoModPlugins.Properties {
             }
             set {
                 this["SetAlpha"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool NativeOnly {
+            get {
+                return ((bool)(this["NativeOnly"]));
+            }
+            set {
+                this["NativeOnly"] = value;
             }
         }
     }

--- a/AutoLegalityMod/Properties/AutoLegality.settings
+++ b/AutoLegalityMod/Properties/AutoLegality.settings
@@ -65,5 +65,8 @@
     <Setting Name="SetAlpha" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+	<Setting Name="NativeOnly" Type="System.Boolean" Scope="User">
+	  <Value Profile="(Default)">True</Value>
+	</Setting>
   </Settings>
 </SettingsFile>

--- a/AutoLegalityMod/app.config
+++ b/AutoLegalityMod/app.config
@@ -76,6 +76,9 @@
             <setting name="SetAlpha" serializeAs="String">
                 <value>False</value>
             </setting>
+			<setting name="NativeOnly" serializeAs="String">
+				<value>True</value>
+			</setting>
         </AutoModPlugins.Properties.AutoLegality>
     </userSettings>
 </configuration>

--- a/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
@@ -37,7 +37,7 @@ namespace PKHeX.Core.AutoMod
         /// <param name="template">rough pkm that has all the <see cref="set"/> values entered</param>
         /// <param name="set">Showdown set object</param>
         /// <param name="satisfied">If the final result is legal or not</param>
-        public static PKM GetLegalFromTemplate(this ITrainerInfo dest, PKM template, IBattleTemplate set, out LegalizationResult satisfied)
+        public static PKM GetLegalFromTemplate(this ITrainerInfo dest, PKM template, IBattleTemplate set, out LegalizationResult satisfied, bool nativeOnly = false)
         {
             RegenSet regen;
             if (set is RegenTemplate t)
@@ -55,23 +55,23 @@ namespace PKHeX.Core.AutoMod
             template.ApplySetDetails(set);
             template.SetRecordFlags(Array.Empty<ushort>()); // Validate TR/MS moves for the encounter
 
-            if (template.Species == (int)Species.Unown) // Force unown form on template
+            if (template.Species == (ushort)Species.Unown) // Force unown form on template
                 template.Form = set.Form;
 
             var abilityreq = GetRequestedAbility(template, set);
             var batchedit = AllowBatchCommands && regen.HasBatchSettings;
+            var native = ModLogic.NativeOnly && nativeOnly;
             var destType = template.GetType();
             var destVer = (GameVersion)dest.Game;
             if (destVer <= 0 && dest is SaveFile s)
                 destVer = s.Version;
 
             var timer = Stopwatch.StartNew();
-            var gamelist = FilteredGameList(template, destVer, batchedit ? regen.Batch.Filters : null);
+            var gamelist = FilteredGameList(template, destVer, batchedit ? regen.Batch.Filters : null, native);
             if (dest.Generation <= 2)
                 template.EXP = 0; // no relearn moves in gen 1/2 so pass level 1 to generator
 
             var encounters = EncounterMovesetGenerator.GenerateEncounters(pk: template, moves: set.Moves, gamelist);
-            // var encounters = GetAllSpeciesFormEncounters(template.Species, GameData.GetPersonal(destVer), gamelist, set.Moves, template);
             var criteria = EncounterCriteria.GetCriteria(set, template.PersonalInfo);
             criteria.ForceMinLevelRange = true;
             if (regen.EncounterFilters != null)
@@ -193,16 +193,17 @@ namespace PKHeX.Core.AutoMod
         /// <param name="destVer">Version in which the pokemon needs to be imported</param>
         /// <param name="filters">Optional list of filters to remove games</param>
         /// <returns>List of filtered games to check encounters for</returns>
-        internal static GameVersion[] FilteredGameList(PKM template, GameVersion destVer, IReadOnlyList<StringInstruction>? filters)
+        internal static GameVersion[] FilteredGameList(PKM template, GameVersion destVer, IReadOnlyList<StringInstruction>? filters, bool nativeOnly = false)
         {
-            var gamelist = GameUtil.GetVersionsWithinRange(template, template.Format).OrderByDescending(c => c.GetGeneration()).ToArray();
+            var gamelist = !nativeOnly
+                           ? GameUtil.GetVersionsWithinRange(template, template.Format).OrderByDescending(c => c.GetGeneration()).ToArray()
+                           : GetPairedVersions(destVer);
 
             if (filters != null)
             {
                 foreach (var f in filters)
                 {
                     if (f.PropertyName == nameof(PKM.Version) && int.TryParse(f.PropertyValue, out int gv))
-                        //gamelist = f.Comparer == InstructionComparer.IsEqual ? new[] { (GameVersion)gv } : gamelist.Where(z => z != (GameVersion)gv).ToArray();
                         gamelist = f.Comparer switch
                         {
                             InstructionComparer.IsEqual => new[] { (GameVersion)gv },
@@ -215,8 +216,10 @@ namespace PKHeX.Core.AutoMod
                         };
                 }
             }
-            if (PrioritizeGame)
+
+            if (PrioritizeGame && !nativeOnly)
                 gamelist = PrioritizeGameVersion == GameVersion.Any ? PrioritizeVersion(gamelist, SimpleEdits.GetIsland(destVer)) : PrioritizeVersion(gamelist, PrioritizeGameVersion);
+
             if (template.AbilityNumber == 4 && destVer.GetGeneration() < 8)
                 gamelist = gamelist.Where(z => z.GetGeneration() is not 3 and not 4).ToArray();
             return gamelist;
@@ -298,7 +301,7 @@ namespace PKHeX.Core.AutoMod
             if (abilityreq == AbilityRequest.Hidden && gen is 3 or 4 && destVer.GetGeneration() < 8)
                 return false;
 
-            if (set.Species == (int)Species.Pikachu)
+            if (set.Species == (ushort)Species.Pikachu)
             {
                 switch (enc.Generation)
                 {
@@ -355,7 +358,7 @@ namespace PKHeX.Core.AutoMod
 
             // Requested alpha but encounter isn't an alpha
             if (enc is not IAlphaReadOnly a)
-                return requested ? false : true;
+                return !requested;
 
             return a.IsAlpha == requested;
         }
@@ -483,14 +486,14 @@ namespace PKHeX.Core.AutoMod
             bool genderValid = pk.IsGenderValid();
             if (!genderValid)
             {
-                if (pk.Format == 4 && pk.Species == (int)Species.Shedinja) // Shedinja glitch
+                if (pk.Format == 4 && pk.Species == (ushort)Species.Shedinja) // Shedinja glitch
                 {
                     // should match original gender
                     var gender = EntityGender.GetFromPIDAndRatio(pk.PID, 0x7F); // 50-50
                     if (gender == pk.Gender)
                         genderValid = true;
                 }
-                else if (pk.Format > 5 && pk.Species is (int)Species.Marill or (int)Species.Azumarill)
+                else if (pk.Format > 5 && pk.Species is (ushort)Species.Marill or (ushort)Species.Azumarill)
                 {
                     var gv = pk.PID & 0xFF;
                     if (gv > 63 && pk.Gender == 1) // evolved from azurill after transferring to keep gender
@@ -1410,13 +1413,13 @@ namespace PKHeX.Core.AutoMod
         /// <summary>
         /// Wrapper function for GetLegalFromTemplate but with a Timeout
         /// </summary>
-        public static PKM GetLegalFromTemplateTimeout(this ITrainerInfo dest, PKM template, IBattleTemplate set, out LegalizationResult satisfied)
+        public static PKM GetLegalFromTemplateTimeout(this ITrainerInfo dest, PKM template, IBattleTemplate set, out LegalizationResult satisfied, bool nativeOnly = false)
         {
             AsyncLegalizationResult GetLegal()
             {
                 try
                 {
-                    var res = dest.GetLegalFromTemplate(template, set, out var s);
+                    var res = dest.GetLegalFromTemplate(template, set, out var s, nativeOnly);
                     return new AsyncLegalizationResult(res, s);
                 }
                 catch (MissingMethodException)
@@ -1462,6 +1465,35 @@ namespace PKHeX.Core.AutoMod
                 return null;
 
             return await task.ConfigureAwait(false); // will re-fire exception if present
+        }
+
+        private static GameVersion[] GetPairedVersions(GameVersion version)
+        {
+            var group = version switch
+            {
+                GameVersion.RD or GameVersion.C => version,
+                _ => GameUtil.GetMetLocationVersionGroup(version),
+            };
+
+            return group switch
+            {
+                GameVersion.RBY => new[] { GameVersion.RD, GameVersion.GN, GameVersion.BU, GameVersion.YW },
+                GameVersion.RSE => new[] { GameVersion.R, GameVersion.S, GameVersion.E },
+                GameVersion.FRLG => new[] { GameVersion.SL, GameVersion.VL },
+                GameVersion.DPPt => new[] { GameVersion.D, GameVersion.P, GameVersion.Pt },
+                GameVersion.HGSS => new[] { GameVersion.HG, GameVersion.SS },
+                GameVersion.BW => new[] { GameVersion.B, GameVersion.W },
+                GameVersion.B2W2 => new[] { GameVersion.B2, GameVersion.W2 },
+                GameVersion.XY => new[] { GameVersion.X, GameVersion.Y },
+                GameVersion.ORAS => new[] { GameVersion.OR, GameVersion.AS },
+                GameVersion.SM => new[] { GameVersion.SN, GameVersion.MN },
+                GameVersion.USUM => new[] { GameVersion.US, GameVersion.UM },
+                GameVersion.GG => new[] { GameVersion.GP, GameVersion.GE },
+                GameVersion.SWSH => new[] { GameVersion.SW, GameVersion.SH },
+                GameVersion.BDSP => new[] { GameVersion.BD, GameVersion.SP },
+                GameVersion.SV => new[] { GameVersion.SL, GameVersion.VL },
+                _ => new[] { version },
+            };
         }
     }
 }

--- a/PKHeX.Core.AutoMod/AutoMod/Legalization/Legalizer.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/Legalization/Legalizer.cs
@@ -145,13 +145,46 @@ namespace PKHeX.Core.AutoMod
         {
             var gen = EasterEggs.GetGeneration(template.Species);
             var species = (ushort)EasterEggs.GetMemeSpecies(gen, template);
+
             template.Species = species;
-            var attempt = 0;
-            var legalencs = tr.GetRandomEncounter(species, null, set.Shiny, false, ref attempt, out var legal);
+            var form = template.GetAvailableForm();
+            if (form == -1)
+                return template;
+
+            template.Form = (byte)form;
+            var legalencs = tr.GetRandomEncounter(template.Species, template.Form, set.Shiny, false, false, out var legal);
             if (legalencs && legal != null)
                 template = legal;
             template.SetNickname(EasterEggs.GetMemeNickname(gen, template));
             return template;
+        }
+
+        private static int GetAvailableForm(this PKM pk)
+        {
+            var species = pk.Species;
+            var pi = pk.PersonalInfo;
+            var formcount = pi.FormCount;
+            if (formcount == 0)
+                return -1;
+
+            if (!(pk.SWSH || pk.BDSP || pk.LA))
+                return pk.Form;
+
+            static bool IsPresentInGameSWSH(ushort species, byte form) => PersonalTable.SWSH.IsPresentInGame(species, form);
+            static bool IsPresentInGameBDSP(ushort species, byte form) => PersonalTable.BDSP.IsPresentInGame(species, form);
+            static bool IsPresentInGameLA(ushort species, byte form) => PersonalTable.LA.IsPresentInGame(species, form);
+            for (byte f = 0; f < formcount; f++)
+            {
+                if (pk.LA && IsPresentInGameLA(species, f))
+                    return f;
+
+                if (pk.BDSP && IsPresentInGameBDSP(species, f))
+                    return f;
+
+                if (pk.SWSH && IsPresentInGameSWSH(species, f))
+                    return f;
+            }
+            return -1;
         }
 
         /// <summary>
@@ -162,9 +195,9 @@ namespace PKHeX.Core.AutoMod
         /// <param name="template">pkm file to legalize</param>
         /// <param name="pkm">legalized pkm file</param>
         /// <returns>bool if the pokemon was legalized</returns>
-        public static LegalizationResult TryAPIConvert(this ITrainerInfo tr, IBattleTemplate set, PKM template, out PKM pkm)
+        public static LegalizationResult TryAPIConvert(this ITrainerInfo tr, IBattleTemplate set, PKM template, out PKM pkm, bool nativeOnly = false)
         {
-            pkm = tr.GetLegalFromTemplateTimeout(template, set, out LegalizationResult satisfied);
+            pkm = tr.GetLegalFromTemplateTimeout(template, set, out LegalizationResult satisfied, nativeOnly);
             if (satisfied != LegalizationResult.Regenerated)
                 return satisfied;
 

--- a/PKHeX.Core.AutoMod/AutoMod/Legalization/SimpleEdits.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/Legalization/SimpleEdits.cs
@@ -65,11 +65,8 @@ namespace PKHeX.Core.AutoMod
             ( Meloetta, 0 ),
 
             // Vivillons
-            ( Scatterbug, 18 ),
             ( Scatterbug, 19 ),
-            ( Spewpa, 18 ),
             ( Spewpa, 19 ),
-            ( Vivillon, 18 ),
             ( Vivillon, 19 ),
 
             // Hoopa
@@ -98,6 +95,29 @@ namespace PKHeX.Core.AutoMod
 
             ( Enamorus, 0 ),
             ( Enamorus, 1 ),
+
+            ( Gimmighoul, 0 ),
+            ( Gimmighoul, 1 ),
+            ( Gholdengo, 0 ),
+            ( WoChien, 0 ),
+            ( ChienPao, 0 ),
+            ( TingLu, 0 ),
+            ( ChiYu, 0 ),
+
+            ( Koraidon, 0 ),
+            ( Koraidon, 1 ),
+            ( Koraidon, 2 ),
+            ( Koraidon, 3 ),
+            ( Koraidon, 4 ),
+
+            ( Miraidon, 0 ),
+            ( Miraidon, 1 ),
+            ( Miraidon, 2 ),
+            ( Miraidon, 3 ),
+            ( Miraidon, 4 ),
+
+            ( WalkingWake, 0 ),
+            ( IronLeaves, 0 ),
         };
 
         public static HashSet<int> Gen1TradeEvos = new () { (int)Kadabra, (int)Machoke, (int)Graveler, (int)Haunter };
@@ -517,9 +537,11 @@ namespace PKHeX.Core.AutoMod
         {
             if (IsUntradeableEncounter(enc))
                 return;
+
             var expect = trainer.IsFromTrainer(pk) ? 0 : 1;
             if (pk.CurrentHandler == expect && expect == 0)
                 return;
+
             pk.CurrentHandler = 1;
             pk.HT_Name = trainer.OT;
             pk.HT_Gender = trainer.Gender;

--- a/PKHeX.Core.AutoMod/AutoMod/Regeneration/RegenTemplate.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/Regeneration/RegenTemplate.cs
@@ -62,7 +62,7 @@ namespace PKHeX.Core.AutoMod
 
         public RegenTemplate(ShowdownSet set, int gen = PKX.Generation) : this(set, gen, set.Text)
         {
-            this.SanitizeForm();
+            this.SanitizeForm(gen);
             this.SanitizeBattleMoves();
 
             var shiny = Shiny ? Core.Shiny.Always : Core.Shiny.Never;
@@ -107,7 +107,7 @@ namespace PKHeX.Core.AutoMod
                 return;
 
             // Sanitize keldeo moves to avoid form mismatches
-            if (set.Species == (int)Core.Species.Keldeo)
+            if (set.Species == (ushort)Core.Species.Keldeo)
                 moves[0] = set.Form == 0 ? (ushort)Move.AquaJet : (ushort)Move.SecretSword;
         }
 

--- a/PKHeX.Core.AutoMod/AutoMod/Regeneration/RegenTemplateExtensions.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/Regeneration/RegenTemplateExtensions.cs
@@ -5,13 +5,12 @@ namespace PKHeX.Core.AutoMod
 {
     public static class RegenTemplateExtensions
     {
-        public static void SanitizeForm(this RegenTemplate set)
+        public static void SanitizeForm(this RegenTemplate set, int gen)
         {
-            var gen = set.Context.Generation();
             if (gen is 9)
             {
                 // Scatterbug and Spewpa must be Fancy
-                if (set.Species == (int)Species.Scatterbug || set.Species == (int)Species.Spewpa)
+                if (set.Species == (ushort)Species.Scatterbug || set.Species == (ushort)Species.Spewpa)
                     set.Form = 18;
                 return;
             }
@@ -28,8 +27,8 @@ namespace PKHeX.Core.AutoMod
         {
             switch (set.Species)
             {
-                case (int)Species.Zacian:
-                case (int)Species.Zamazenta:
+                case (ushort)Species.Zacian:
+                case (ushort)Species.Zamazenta:
                     {
                         // Behemoth Blade and Behemoth Bash -> Iron Head
                         if (!set.Moves.Contains((ushort)781) && !set.Moves.Contains((ushort)782))


### PR DESCRIPTION
- Hopefully fix living dex (Vivillon family, Gholdengo, handle some missing forms).
- Add an option to generate a native living dex (no transfers, only what's available in game version pairs).
- Pass correct generation context to `RegenTemplate`.