### PR TITLE
Update check tweaks.

### DIFF
--- a/AutoLegalityMod/GUI/ALMSettings.Designer.cs
+++ b/AutoLegalityMod/GUI/ALMSettings.Designer.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Diagnostics;
-using System.Reflection;
-using System.Windows.Forms;
-
-namespace AutoModPlugins.GUI
+﻿namespace AutoModPlugins.GUI
 {
     partial class ALMSettings
     {

--- a/AutoLegalityMod/GUI/ALMSettings.cs
+++ b/AutoLegalityMod/GUI/ALMSettings.cs
@@ -44,6 +44,7 @@ namespace AutoModPlugins.GUI
             new("PromptForSmogonImport", "Used for \"Generate Smogon Sets\". If set to true, ALM will ask for approval for each set before attempting to generate it.", "Miscellaneous"),
             new("UseMarkings", "Sets markings on the Pokémon based on IVs.", "Miscellaneous"),
             new("UseCompetitiveMarkings", "Sets IVs of 31 to blue and 30 to red if enabled. Otherwise, sets IVs of 31 to blue and 0 to red.", "Miscellaneous"),
+            new("AllowMismatch", "If enabled, ignores version mismatch warnings until the next PKHeX.Core release.", "Miscellaneous"),
         };
 
         public ALMSettings(object obj)
@@ -93,7 +94,7 @@ namespace AutoModPlugins.GUI
                 if (s.Category != null)
                     category = translation.GetTranslatedText($"{s.SettingName}_category", s.Category);
                 if (desc == null || category == null)
-                    throw new ArgumentOutOfRangeException("Category / Description translations are null");
+                    throw new Exception("Category / Description translations are null");
                 PropertyDescriptor pd2 = TypeDescriptor.CreateProperty(_settings.GetType(), pd, new DescriptionAttribute(desc), new CategoryAttribute(category));
                 ctd.OverrideProperty(pd2);
             }

--- a/AutoLegalityMod/GUI/ShowdownSetLoader.cs
+++ b/AutoLegalityMod/GUI/ShowdownSetLoader.cs
@@ -95,8 +95,9 @@ namespace AutoModPlugins
             if (msg is LegalizationResult.VersionMismatch)
             {
                 var errorstr = "The PKHeX-Plugins version does not match the PKHeX version.\n\n" +
-                    $"Refer to the Wiki to fix this error.\n\nThe current ALM Version is {ALMVersion.GetCurrentVersion("PKHeX.Core.AutoMod")}\n" +
-                    $"The current PKHeX Version is {ALMVersion.GetCurrentVersion("PKHeX.Core")}";
+                    $"Refer to the Wiki to fix this error.\n\n" +
+                    $"The current ALM Version is {ALMVersion.Versions.AlmVersionCurrent}\n" +
+                    $"The current PKHeX Version is {ALMVersion.Versions.CoreVersionCurrent}";
 
                 var res = WinFormsUtil.ALMErrorBasic(errorstr);
                 if (res == DialogResult.Retry)
@@ -157,8 +158,8 @@ namespace AutoModPlugins
             if (result is AutoModErrorCode.VersionMismatch)
             {
                 var errorstr = "The PKHeX-Plugins version does not match the PKHeX version.\nRefer to the Wiki for how to fix this error.\n\n" +
-                    $"The current ALM Version is {ALMVersion.GetCurrentVersion("PKHeX.Core.AutoMod")}\n" +
-                    $"The current PKHeX Version is {ALMVersion.GetCurrentVersion("PKHeX.Core")}";
+                    $"The current ALM Version is {ALMVersion.Versions.AlmVersionCurrent}\n" +
+                    $"The current PKHeX Version is {ALMVersion.Versions.CoreVersionCurrent}";
 
                 var res = WinFormsUtil.ALMErrorBasic(errorstr);
                 if (res == DialogResult.Retry)
@@ -188,6 +189,7 @@ namespace AutoModPlugins
             APILegality.ForceSpecifiedBall = settings.ForceSpecifiedBall;
             APILegality.UseCompetitiveMarkings = settings.UseCompetitiveMarkings;
             APILegality.UseMarkings = settings.UseMarkings;
+            APILegality.AllowMismatch = settings.AllowMismatch;
             APILegality.UseXOROSHIRO = settings.UseXOROSHIRO;
             APILegality.PrioritizeGame = settings.PrioritizeGame;
             APILegality.PrioritizeGameVersion = settings.PriorityGameVersion;
@@ -203,6 +205,13 @@ namespace AutoModPlugins
 
             if (APILegality.UseCompetitiveMarkings)
                 MarkingApplicator.MarkingMethod = APILegality.CompetitiveMarking;
+
+            if (APILegality.AllowMismatch && settings.LatestAllowedVersion == "0.0.0.0")
+            {
+                settings.LatestAllowedVersion = ALMVersion.Versions.CoreVersionLatest?.ToString() ?? "0.0.0.0";
+                APILegality.LatestAllowedVersion = settings.LatestAllowedVersion;
+            }
+            else APILegality.LatestAllowedVersion = settings.LatestAllowedVersion;
 
             settings.PrioritizeEncounters ??= EncounterPriority.ToList();
             foreach (var ep in EncounterPriority)

--- a/AutoLegalityMod/GUI/WinFormsUtil.cs
+++ b/AutoLegalityMod/GUI/WinFormsUtil.cs
@@ -36,12 +36,16 @@ namespace AutoModPlugins
             return MessageBox.Show(msg, nameof(Error), MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
 
-        public static ALMError ALMErrorDiscord(Version version, bool mismatch)
+        public static ALMError ALMErrorDiscord(Version? version, bool update, bool mismatch)
         {
             // ReSharper disable once SuspiciousTypeConversion.Global
-            var msg = $"Update for ALM is available. Please download it from GitHub. The updated release is only compatible with PKHeX version: {version.Major}.{version.Minor}.{version.Build}.";
+            var msg = string.Empty;
+            if (update)
+                msg += $"Update for ALM is available. Please download it from GitHub. The updated release is only compatible with PKHeX version: {version}.";
+
             if (mismatch)
-                msg += "\n\nThere is also a possible version mismatch between the current ALM version and current PKHeX version.";
+                msg += $"{(update ? "\n\n" : "")}Possible version mismatch between the current ALM version and current PKHeX version.";
+
             msg += "Click on the GitHub button to get the latest update for ALM.\nClick on the Discord button if you still require further assistance.";
             return new ALMError(msg, new[] { "Discord", "GitHub", "Cancel" });
         }

--- a/AutoLegalityMod/Plugins/LegalizeBoxes.cs
+++ b/AutoLegalityMod/Plugins/LegalizeBoxes.cs
@@ -40,8 +40,8 @@ namespace AutoModPlugins
             catch (MissingMethodException)
             {
                 var errorstr = "The PKHeX-Plugins version does not match the PKHeX version. \nRefer to the Wiki for how to fix this error.\n\n" +
-                              $"The current ALM Version is {ALMVersion.GetCurrentVersion("PKHeX.Core.AutoMod")}\n" +
-                              $"The current PKHeX Version is {ALMVersion.GetCurrentVersion("PKHeX.Core")}";
+                              $"The current ALM Version is {ALMVersion.Versions.AlmVersionCurrent}\n" +
+                              $"The current PKHeX Version is {ALMVersion.Versions.CoreVersionCurrent}";
 
                 var res = WinFormsUtil.ALMErrorBasic(errorstr);
                 if (res == DialogResult.Retry)

--- a/AutoLegalityMod/Properties/AutoLegality.Designer.cs
+++ b/AutoLegalityMod/Properties/AutoLegality.Designer.cs
@@ -8,6 +8,8 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
+using System.ComponentModel;
+
 namespace AutoModPlugins.Properties {
     
     
@@ -94,7 +96,38 @@ namespace AutoModPlugins.Properties {
                 this["UseMarkings"] = value;
             }
         }
-        
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool AllowMismatch
+        {
+            get
+            {
+                return ((bool)(this["AllowMismatch"]));
+            }
+            set
+            {
+                this["AllowMismatch"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0.0.0.0")]
+        [Browsable(false)]
+        public string LatestAllowedVersion
+        {
+            get
+            {
+                return ((string)(this["LatestAllowedVersion"]));
+            }
+            set
+            {
+                this["LatestAllowedVersion"] = value;
+            }
+        }
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]

--- a/AutoLegalityMod/app.config
+++ b/AutoLegalityMod/app.config
@@ -76,9 +76,15 @@
             <setting name="SetAlpha" serializeAs="String">
                 <value>False</value>
             </setting>
-			<setting name="NativeOnly" serializeAs="String">
-				<value>True</value>
-			</setting>
+            <setting name="NativeOnly" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="AllowMismatch" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="LatestAllowedVersion" serializeAs="String">
+                <value>0.0.0.0</value>
+            </setting>
         </AutoModPlugins.Properties.AutoLegality>
     </userSettings>
 </configuration>

--- a/AutoModTests/ShowdownSets/Anubis Tests/Anubis - pk9.txt
+++ b/AutoModTests/ShowdownSets/Anubis Tests/Anubis - pk9.txt
@@ -9327,3 +9327,16 @@ Pikachu
 Pikachu
 ~=Generation=9
 .RibbonMarkMightiest=True
+
+Vivillon-High-Plains (F)
+IVs: 12 HP / 9 Atk / 13 Def / 12 SpA / 0 SpD / 28 Spe
+Ability: Shield Dust
+Tera Type: Bug
+Level: 47
+Shiny: Yes
+Naive Nature
+~=Generation=9
+- Draining Kiss
+- Safeguard
+- Bug Buzz
+- Quiver Dance

--- a/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
@@ -21,6 +21,8 @@ namespace PKHeX.Core.AutoMod
         public static bool SetAllLegalRibbons { get; set; } = true;
         public static bool UseCompetitiveMarkings { get; set; }
         public static bool UseMarkings { get; set; } = true;
+        public static bool AllowMismatch { get; set; } = false;
+        public static string LatestAllowedVersion { get; set; } = "0.0.0.0";
         public static bool UseXOROSHIRO { get; set; } = true;
         public static bool PrioritizeGame { get; set; } = true;
         public static GameVersion PrioritizeGameVersion { get; set; }
@@ -1421,9 +1423,7 @@ namespace PKHeX.Core.AutoMod
             {
                 try
                 {
-                    var almVer = ALMVersion.GetCurrentVersion("PKHeX.Core.AutoMod");
-                    var coreVer = ALMVersion.GetCurrentVersion("PKHeX.Core");
-                    if (coreVer > almVer)
+                    if (ALMVersion.GetIsMismatch())
                         return new(template, LegalizationResult.VersionMismatch);
 
                     var res = dest.GetLegalFromTemplate(template, set, out var s, nativeOnly);

--- a/PKHeX.Core.AutoMod/AutoMod/Util/Version.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/Util/Version.cs
@@ -1,12 +1,8 @@
 ﻿using System;
-using System.IO;
 using System.Linq;
-using System.Net.Http;
 using System.Reflection;
 using System.Diagnostics;
-using System.Threading.Tasks;
 using System.Text.RegularExpressions;
-using System.Threading;
 
 namespace PKHeX.Core.AutoMod
 {
@@ -16,12 +12,40 @@ namespace PKHeX.Core.AutoMod
         private static partial Regex GetLatestGitTag();
         private static readonly Regex LatestGitTagRegex = GetLatestGitTag(); // Match `"tag_name": "18.12.02"`. Group 1 is `18.12.02`
         private static readonly Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
+        public static readonly AssemblyVersions Versions = new();
+
+        public record AssemblyVersions
+        {
+            public readonly Version? AlmVersionCurrent = GetCurrentVersion("PKHeX.Core.AutoMod");
+            public readonly Version? AlmVersionLatest = GetLatestALMVersion();
+
+            public readonly Version? CoreVersionCurrent = GetCurrentVersion("PKHeX.Core");
+            public readonly Version? CoreVersionLatest = GetLatestCoreVersion();
+        }
+
+        /// <summary>
+        /// Checks for plugin mismatch. If "AllowMismatch" is enabled it will allow a user to skip update warnings until the next release. Will otherwise check plugin mismatch for current versions.
+        /// </summary>
+        /// <returns>True if a plugin mismatch is found. False if any of the versions are null or no mismatch found.</returns>
+        public static bool GetIsMismatch()
+            => GetIsMismatch(currentCore: Versions.CoreVersionCurrent, currentALM: Versions.AlmVersionCurrent, latestCore: Versions.CoreVersionLatest, latestALM: Versions.AlmVersionLatest);
+
+        public static bool GetIsMismatch(Version? currentCore, Version? currentALM, Version? latestCore, Version? latestALM)
+        {
+            if (currentCore is null || currentALM is null || latestCore is null || latestALM is null)
+                return false;
+
+            var latestAllowed = new Version(APILegality.LatestAllowedVersion);
+            if (APILegality.AllowMismatch && (latestCore > latestAllowed))
+                return true;
+            return !APILegality.AllowMismatch && (currentCore > currentALM);
+        }
 
         /// <summary>
         /// Gets the current version of the specified assembly.
         /// </summary>
         /// <returns>A version representing the current version of the specified assembly, or null if the assembly cannot be found or has no version available.</returns>
-        public static Version? GetCurrentVersion(string assemblyName)
+        private static Version? GetCurrentVersion(string assemblyName)
         {
             var assembly = assemblies.FirstOrDefault(x => x.GetName().Name == assemblyName);
             return assembly?.GetName().Version;
@@ -31,45 +55,41 @@ namespace PKHeX.Core.AutoMod
         /// Gets the latest version of ALM according to the Github API
         /// </summary>
         /// <returns>A version representing the latest available version of PKHeX, or null if the latest version could not be determined.</returns>
-        public static async Task<Version?> GetLatestALMVersion(CancellationToken token)
-        {
-            const string apiEndpoint = "https://api.github.com/repos/architdate/pkhex-plugins/releases/latest";
-            var responseJson = await GetStringFromURL(apiEndpoint, token).ConfigureAwait(false);
-            if (string.IsNullOrEmpty(responseJson))
-                return null;
-
-            // Using a regex to get the tag to avoid importing an entire JSON parsing library
-            var tagMatch = LatestGitTagRegex.Match(responseJson);
-            if (!tagMatch.Success)
-                return null;
-
-            var tagString = tagMatch.Groups[1].Value;
-            return !Version.TryParse(tagString, out var latestVersion) ? null : latestVersion;
-        }
-
-        private static async Task<string?> GetStringFromURL(string url, CancellationToken token)
+        private static Version? GetLatestALMVersion()
         {
             try
             {
-                var stream = await GetStreamFromURL(url, token).ConfigureAwait(false);
-                using var reader = new StreamReader(stream);
-                return reader.ReadToEnd();
+                const string apiEndpoint = "https://api.github.com/repos/architdate/pkhex-plugins/releases/latest";
+                var responseJson = NetUtil.GetStringFromURL(new Uri(apiEndpoint));
+                if (responseJson is null)
+                    return null;
+
+                // Using a regex to get the tag to avoid importing an entire JSON parsing library
+                var tagMatch = LatestGitTagRegex.Match(responseJson);
+                if (!tagMatch.Success)
+                    return null;
+
+                var tagString = tagMatch.Groups[1].Value;
+                return !Version.TryParse(tagString, out var latestVersion) ? null : latestVersion;
             }
-            // No internet?
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Debug.WriteLine(e.Message);
+                Debug.WriteLine(ex.Message);
                 return null;
             }
         }
 
-        private static async Task<Stream> GetStreamFromURL(string url, CancellationToken token)
+        private static Version? GetLatestCoreVersion()
         {
-            using var client = new HttpClient();
-            const string agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36";
-            client.DefaultRequestHeaders.Add("User-Agent", agent);
-            var response = await client.GetAsync(url, token).ConfigureAwait(false);
-            return await response.Content.ReadAsStreamAsync(token).ConfigureAwait(false);
+            try
+            {
+                return UpdateUtil.GetLatestPKHeXVersion();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(ex.Message);
+                return null;
+            }
         }
     }
 }


### PR DESCRIPTION
- Add option to temporarily disable version mismatch warnings.
- Check latest Core version and resume nagging if a user has been skipping updates for too long.
- Add test set for Vivillon, add test for version mismatch.