### PR TITLE
Replace appveyor with Azure Pipelines in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Regular builds will usually succeed unless there are changes that are incompatib
    - The compiled DLL `AutoModPlugins.dll` for AutoLegality will be in the `AutoLegalityMod\bin\Release\net7.0-windows` directory.
 
 **Bleeding Edge Builds**  
-Use this build method only if the regular builds fail. The AppVeyor CI will always use the bleeding edge build method. More details regarding this can be seen in the [appveyor.yml](https://github.com/architdate/PKHeX-Plugins/blob/master/appveyor.yml) file.
+Use this build method only if the regular builds fail. The Azure Pipelines CI will always use the bleeding edge build method. More details regarding this can be seen in the [azure-pipelines.yml](https://github.com/architdate/PKHeX-Plugins/blob/master/azure-pipelines.yml) file.
 
 - Clone the PKHeX repository using: `$ git clone https://github.com/kwsch/PKHeX.git`.
 - Clone the PKHeX-Plugins repository using: `$ git clone https://github.com/architdate/PKHeX-Plugins.git`.


### PR DESCRIPTION
Noticed the url to the appveyor.yml file was broken, hence the PR.