### PR TITLE
Fix GPSS Uploading

### DIFF
--- a/AutoLegalityMod/Plugins/GPSSPlugin.cs
+++ b/AutoLegalityMod/Plugins/GPSSPlugin.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Windows.Forms;
 using AutoModPlugins.Properties;
 using PKHeX.Core;
@@ -26,13 +28,62 @@ namespace AutoModPlugins
             modmenu.DropDownItems.Add(ctrl);
         }
 
-        private void GPSSUpload(object? sender, EventArgs e)
+        private async void GPSSUpload(object? sender, EventArgs e)
         {
             var pk = PKMEditor.PreparePKM();
             byte[] rawdata = pk.Data;
-            var postval = PKHeX.Core.Enhancements.NetUtil.GPSSPost(rawdata, SaveFileEditor.SAV.Generation, Url);
-            Clipboard.SetText(postval);
-            WinFormsUtil.Alert(postval);
+            try
+            {
+                var response = await PKHeX.Core.Enhancements.NetUtil.GPSSPost(rawdata, SaveFileEditor.SAV.Generation, Url);
+
+                var content = await response.Content.ReadAsStringAsync();
+                var decoded = JsonSerializer.Deserialize<JsonNode>(content);
+                var error = (string)decoded["error"];
+                var msg = "";
+                var copyToClipboard = false;
+                // TODO set proper status codes on FlagBrew side - Allen;
+                if (response.IsSuccessStatusCode)
+                {
+                    if (error != null && error != "no errors")
+                    {
+                        switch (error)
+                        {
+                            case "your pokemon is being held for manual review":
+                                msg = $"Your pokemon was uploaded to GPSS, however it is being held for manual review. Once approved it will be available at https://{Url}/gpss/{decoded["code"]} (copied to clipboard)";
+                                copyToClipboard = true;
+                                break;
+                            case "Your Pokemon is already uploaded":
+                                msg = $"Your pokemon was already uploaded to GPSS, and is available at https://{Url}/gpss/{decoded["code"]} (copied to clipboard)";
+                                copyToClipboard = true;
+                                break;
+                            default:
+                                msg = $"Could not upload your Pokemon to GPSS, please try again later or ask Allen if something seems wrong.\n Error details: {decoded["code"]}";
+                                break;
+                        }
+                    }
+                    else
+                    {
+                        msg = $"Pokemon added to the GPSS database. Here is your URL (has been copied to the clipboard):\n https://{Url}/gpss/{decoded["code"]}";
+                        copyToClipboard = true;
+                    }
+                } else if (response.StatusCode == System.Net.HttpStatusCode.ServiceUnavailable)
+                {
+                    msg = "Uploading to GPSS is currently disabled, please try again later, or check the FlagBrew discord for more information.";
+                } else
+                {
+                    msg = $"Uploading to GPSS returned an unexpected status code {response.StatusCode}\nError details (if any returned from server): {error}";
+                }
+                
+
+                if (copyToClipboard)
+                {
+                    Clipboard.SetText($"https://{Url}/gpss/{decoded["code"]}");
+                }
+                WinFormsUtil.Alert(msg);
+            } catch (Exception ex)
+            {
+                WinFormsUtil.Alert($"Something went wrong uploading to GPSS.\nError details: {ex.Message}");
+            }
         }
 
         private void GPSSDownload(object? sender, EventArgs e)

--- a/AutoLegalityMod/Plugins/GPSSPlugin.cs
+++ b/AutoLegalityMod/Plugins/GPSSPlugin.cs
@@ -30,7 +30,7 @@ namespace AutoModPlugins
         {
             var pk = PKMEditor.PreparePKM();
             byte[] rawdata = pk.Data;
-            var postval = PKHeX.Core.Enhancements.NetUtil.GPSSPost(rawdata, Url);
+            var postval = PKHeX.Core.Enhancements.NetUtil.GPSSPost(rawdata, SaveFileEditor.SAV.Generation, Url);
             Clipboard.SetText(postval);
             WinFormsUtil.Alert(postval);
         }

--- a/PKHeX.Core.Enhancements/Enhancements/NetUtil.cs
+++ b/PKHeX.Core.Enhancements/Enhancements/NetUtil.cs
@@ -81,7 +81,7 @@ namespace PKHeX.Core.Enhancements
             uploadData.Headers.Add("source", "PKHeX AutoMod Plugins");
             uploadData.Headers.Add("generation", generation.ToString());
 
-            var response = await client.PostAsync($"http://{Url}/api/v2/gpss/upload/pokemon", uploadData);
+            var response = await client.PostAsync($"https://{Url}/api/v2/gpss/upload/pokemon", uploadData);
             return response;
         }
 

--- a/PKHeX.Core.Enhancements/Enhancements/NetUtil.cs
+++ b/PKHeX.Core.Enhancements/Enhancements/NetUtil.cs
@@ -66,11 +66,12 @@ namespace PKHeX.Core.Enhancements
         /// </summary>
         /// <param name="data">pkm data in bytes.</param>
         /// <param name="Url">location to fetch from</param>
+        /// <param name="generation">The generation for the game the pokemon is being uploaded from.</param>
         /// <returns></returns>
-        public static string GPSSPost(byte[] data, string Url = "flagbrew.org")
+        public static string GPSSPost(byte[] data, int generation, string Url = "flagbrew.org")
         {
 #pragma warning disable SYSLIB0014 // Type or member is obsolete
-            WebRequest request = WebRequest.Create($"https://{Url}/gpss/share");
+            WebRequest request = WebRequest.Create($"https://{Url}/api/v2/gpss/upload/pokemon");
 #pragma warning restore SYSLIB0014 // Type or member is obsolete
             request.Method = "POST";
             const string boundary = "-----------";
@@ -88,6 +89,12 @@ namespace PKHeX.Core.Enhancements
             sb.Append("\r\n");
             sb.Append("Content-Type: ");
             sb.Append("application/octet-stream");
+            sb.Append("\r\n");
+            sb.Append("source: ");
+            sb.Append("PKHeX Plugins");
+            sb.Append("\r\n");
+            sb.Append("generation: ");
+            sb.Append(generation);
             sb.Append("\r\n");
             sb.Append("\r\n");
 

--- a/PKHeX.Core.Enhancements/Enhancements/NetUtil.cs
+++ b/PKHeX.Core.Enhancements/Enhancements/NetUtil.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace PKHeX.Core.Enhancements
 {
@@ -68,71 +69,20 @@ namespace PKHeX.Core.Enhancements
         /// <param name="Url">location to fetch from</param>
         /// <param name="generation">The generation for the game the pokemon is being uploaded from.</param>
         /// <returns></returns>
-        public static string GPSSPost(byte[] data, int generation, string Url = "flagbrew.org")
+        public async static Task<HttpResponseMessage> GPSSPost(byte[] data, int generation, string Url = "flagbrew.org")
         {
-#pragma warning disable SYSLIB0014 // Type or member is obsolete
-            WebRequest request = WebRequest.Create($"https://{Url}/api/v2/gpss/upload/pokemon");
-#pragma warning restore SYSLIB0014 // Type or member is obsolete
-            request.Method = "POST";
-            const string boundary = "-----------";
-            request.ContentType = "multipart/form-data; boundary=" + boundary;
-            // Build up the post message header  
-            StringBuilder sb = new();
-            sb.Append("--");
-            sb.Append(boundary);
-            sb.Append("\r\n");
-            sb.Append("Content-Disposition: form-data; name=\"");
-            sb.Append("pkmn");
-            sb.Append("\"; filename=\"");
-            sb.Append("file");
-            sb.Append("\"");
-            sb.Append("\r\n");
-            sb.Append("Content-Type: ");
-            sb.Append("application/octet-stream");
-            sb.Append("\r\n");
-            sb.Append("source: ");
-            sb.Append("PKHeX Plugins");
-            sb.Append("\r\n");
-            sb.Append("generation: ");
-            sb.Append(generation);
-            sb.Append("\r\n");
-            sb.Append("\r\n");
+            using var client = new HttpClient();
 
-            string postHeader = sb.ToString();
-            byte[] postHeaderBytes = Encoding.UTF8.GetBytes(postHeader);
-            byte[] boundaryBytes = Encoding.ASCII.GetBytes($"\r\n--{boundary}\r\n");
-            long length = postHeaderBytes.Length + data.Length + boundaryBytes.Length;
-            request.ContentLength = length;
-            using (Stream datastream = request.GetRequestStream())
+            var uploadData = new MultipartFormDataContent
             {
-                datastream.Write(postHeaderBytes, 0, postHeaderBytes.Length);
-                datastream.Write(data, 0, data.Length);
-                datastream.Write(boundaryBytes, 0, boundaryBytes.Length);
-            }
-            // Get the response.
-            try
-            {
-                using var response = request.GetResponse();
-                using var responseStream = response.GetResponseStream();
-                if (responseStream == null)
-                    return string.Empty;
-                using StreamReader reader = new(responseStream);
-                string responseFromServer = reader.ReadToEnd();
-                return $"Pokemon added to the GPSS database. Here is your URL (has been copied to the clipboard):\n https://{Url}/gpss/" + responseFromServer;
-            }
-            catch (WebException e)
-            {
-                var exstr = "Exception: \n";
-                if (e.Status == WebExceptionStatus.ProtocolError)
-#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
-#pragma warning disable CS8602 // Dereference of a possibly null reference.
-                    exstr += $"Status Code : {((HttpWebResponse)e.Response).StatusCode}\nStatus Description : {((HttpWebResponse)e.Response).StatusDescription}";
-#pragma warning restore CS8602 // Dereference of a possibly null reference.
-#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
-                else
-                    exstr += e.Message;
-                return exstr;
-            }
+                { new ByteArrayContent(data), "pkmn", "pkmn" }
+            };
+
+            uploadData.Headers.Add("source", "PKHeX AutoMod Plugins");
+            uploadData.Headers.Add("generation", generation.ToString());
+
+            var response = await client.PostAsync($"http://{Url}/api/v2/gpss/upload/pokemon", uploadData);
+            return response;
         }
 
         /// <summary>


### PR DESCRIPTION
### Info
As of 2023-06-17 @ 6:21 PM (AST) all FlagBrew V1 endpoints were disabled, this means that uploading to GPSS in the current version of PKHeX-Plugins is no longer possible.

This PR aims to fix that and to also rewrite the uploading function to be a bit more modern.

### Changelog
- Fixed uploading to GPSS by switching to v2 endpoint
- Cleaned up upload code and added a bit more context to error messages that get returned.
   - There is still a TODO that can only be done by me on the actual service side, but for now this should be acceptable.