### PR TITLE
Fix pkm generation for EncounterDist9 and EncounterMight9

### DIFF
--- a/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
@@ -899,7 +899,7 @@ namespace PKHeX.Core.AutoMod
                 ulong seed = GetRandomULong();
                 const byte rollCount = 1;
                 const byte undefinedSize = 0;
-                var pi = PersonalTable.SV.GetFormEntry(pk.Species, pk.Form);
+                var pi = PersonalTable.SV.GetFormEntry(enc.Species, enc.Form);
                 var param = enc switch
                 {
                     EncounterDist9 dist => new GenerateParam9(pk.Species, pi.Gender, dist.FlawlessIVCount, rollCount,

--- a/PKHeX.Core.AutoMod/AutoMod/Legalization/SimpleEdits.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/Legalization/SimpleEdits.cs
@@ -96,9 +96,7 @@ namespace PKHeX.Core.AutoMod
             ( Enamorus, 0 ),
             ( Enamorus, 1 ),
 
-            ( Gimmighoul, 0 ),
             ( Gimmighoul, 1 ),
-            ( Gholdengo, 0 ),
             ( WoChien, 0 ),
             ( ChienPao, 0 ),
             ( TingLu, 0 ),


### PR DESCRIPTION
This also fixes the Shiny Gimmighoul and Shiny Gholdengo requests.

**Context:**
Showdown sets like
```
Gimmighoul
Shiny: Yes
```

or
```
Gholdengo
Shiny: Yes
```

could not be generated by ALM.

A first fix was attempted by duplicating the `FindTeraPIDIV` method in the `APILegality.cs` to accept an `EncounterDist9` parameter.
That broke the generation for the `EncounterDist9` with fixed Scale, like the WalkingWake/IronLeaves event.
It appeared that the `GenerateParam9` initialization in the `FindTeraPIDIV` method was matching the PKHeX' [SetPINGA](https://github.com/kwsch/PKHeX/blob/26cabd022b09c2ed75773afdafcd3387a5416d52/PKHeX.Core/Legality/Encounters/EncounterStatic/EncounterTera9.cs#L169) method for EncounterTera9. 

The code was then adapted to switch the GenerateParam9 initialization based on the `ITeraRaid9` type (EncounterDist9 - EncounterMight9 - EncounterTera9). This solved the issues, and allowed Shiny Gimmighoul to be generated correctly, as well as Dist and Might events with set encounter details.

Co-Authored-By: santacrab2 <79347566+santacrab2@users.noreply.github.com>