### PR TITLE
Modify HOME Tracker checks

### DIFF
--- a/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
@@ -150,7 +150,7 @@ namespace PKHeX.Core.AutoMod
 
                 if (HomeTrackerUtil.IsRequired(enc, pk) && !AllowHOMETransferGeneration)
                     continue;
-
+                
                 // Apply final details
                 ApplySetDetails(pk, set, dest, enc, regen, tb);
 
@@ -174,14 +174,17 @@ namespace PKHeX.Core.AutoMod
                         continue;
                     pk.ApplyPostBatchFixes();
                 }
-
+                
                 if (pk is PK1 pk1 && pk1.TradebackValid())
                 {
                     satisfied = LegalizationResult.Regenerated;
                     return pk;
                 }
-
                 // Verify the Legality of what we generated, and exit if it is valid.
+                if(!AllowHOMETransferGeneration)
+                    typeof(ParseSettings).GetProperty(nameof(ParseSettings.Gen8TransferTrackerNotPresent))!.SetValue(null, Severity.Invalid);
+                else
+                    typeof(ParseSettings).GetProperty(nameof(ParseSettings.Gen8TransferTrackerNotPresent))!.SetValue(null, Severity.Fishy);
                 var la = new LegalityAnalysis(pk);
                 if (la.Valid && pk.Species == set.Species) // Encounter Trades that evolve may cause higher tahn expected species
                 {
@@ -301,7 +304,7 @@ namespace PKHeX.Core.AutoMod
                 return single;
 
             var versionlist = GameUtil.GetVersionsWithinRange(template, template.Format);
-            var gamelist = !nativeOnly
+            var gamelist = (!nativeOnly && AllowHOMETransferGeneration)
                 ? versionlist.OrderByDescending(c => c.GetGeneration()).ToArray()
                 : GetPairedVersions(destVer, versionlist);
 

--- a/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
+++ b/PKHeX.Core.AutoMod/AutoMod/APILegality.cs
@@ -181,10 +181,6 @@ namespace PKHeX.Core.AutoMod
                     return pk;
                 }
                 // Verify the Legality of what we generated, and exit if it is valid.
-                if(!AllowHOMETransferGeneration)
-                    typeof(ParseSettings).GetProperty(nameof(ParseSettings.Gen8TransferTrackerNotPresent))!.SetValue(null, Severity.Invalid);
-                else
-                    typeof(ParseSettings).GetProperty(nameof(ParseSettings.Gen8TransferTrackerNotPresent))!.SetValue(null, Severity.Fishy);
                 var la = new LegalityAnalysis(pk);
                 if (la.Valid && pk.Species == set.Species) // Encounter Trades that evolve may cause higher tahn expected species
                 {


### PR DESCRIPTION
- Only grab encounters from the current version pair if AllowHomeTransferGeneration is set to false

- Modify the legality check settings to block All transfer encounters and not just GO, Home Gifts and prior to gen 8 mons. e.g. SV pikachu with Galar Champion Ribbon.