### PR TITLE
Fix Living Dex generation in Gen 9

### DIFF
--- a/PKHeX.Core.AutoMod/Enhancements/ModLogic.cs
+++ b/PKHeX.Core.AutoMod/Enhancements/ModLogic.cs
@@ -272,7 +272,7 @@ namespace PKHeX.Core.AutoMod
                     return true;
                 case Species.Arceus when generation == 4 && form == 9: // ??? form
                     return true;
-                case Species.Scatterbug or Species.Spewpa when form > Vivillon3DS.MaxWildFormID:
+                case Species.Scatterbug or Species.Spewpa when generation != 9 && form > Vivillon3DS.MaxWildFormID || generation == 9 && form != Vivillon3DS.FancyFormID:
                     return true;
             }
             if (FormInfo.IsBattleOnlyForm(pk.Species, form, generation))


### PR DESCRIPTION
Fixes expected count failing to find valid encounters for Scatterbug and Spewpa
Fixes VerifyDex unit test
![image](https://github.com/architdate/PKHeX-Plugins/assets/24732684/6dc82365-60ea-4831-bd16-d019788c6223)
